### PR TITLE
[feat] 영화 및 배우 S3 이미지 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,43 +42,54 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          envs: |
+            ENV_FILE_CONTENT_FROM_SECRET: ${{ secrets.DOT_ENV_CONTENTS }}
           script: |
-            set -e # 오류 발생 시 즉시 스크립트 중단
+            set -e
 
-            EC2_HOME_DIR="/home/${{ secrets.EC2_USERNAME }}"
-            JAR_SOURCE_DIR_ON_EC2="$EC2_HOME_DIR/build/libs" 
-            FINAL_TARGET_JAR_PATH="$EC2_HOME_DIR/app.jar"
+            EC2_APP_DIR="/home/${{ secrets.EC2_USERNAME }}"
+            ENV_FILE_PATH="$EC2_APP_DIR/.env"
+            FINAL_TARGET_JAR_PATH="$EC2_APP_DIR/app.jar"
             JAR_FILE_PATTERN="picobox-*.jar"
 
-            echo "--- Navigating to JAR directory on EC2: $JAR_SOURCE_DIR_ON_EC2 ---"
-            cd "$JAR_SOURCE_DIR_ON_EC2"
+            echo "--- Creating/Updating environment file at $ENV_FILE_PATH from a single GitHub Secret ---"
+            printf '%s\n' "$ENV_FILE_CONTENT_FROM_SECRET" > "$ENV_FILE_PATH"
+            chmod 600 "$ENV_FILE_PATH"
+            echo "Environment file successfully created/updated at $ENV_FILE_PATH."
+
+            echo "--- Navigating to application directory on EC2: $EC2_APP_DIR ---"
+            cd "$EC2_APP_DIR"
             
-            echo "--- Locating JAR file (pattern: $JAR_FILE_PATTERN) ---"
+            echo "--- Locating newly copied JAR file (pattern: $JAR_FILE_PATTERN) ---"
             COPIED_JAR_NAME=$(ls -t $JAR_FILE_PATTERN 2>/dev/null | grep -v -- '-plain\.jar$' | head -n 1)
 
             if [ -z "$COPIED_JAR_NAME" ]; then
-              echo "Error: JAR file matching '$JAR_FILE_PATTERN' not found in $JAR_SOURCE_DIR_ON_EC2."
-              COPIED_JAR_NAME=$(ls -t *.jar 2>/dev/null | grep -v -- '-plain\.jar$' | head -n 1)
-              if [ -z "$COPIED_JAR_NAME" ]; then
-                echo "Error: No suitable .jar file found in $JAR_SOURCE_DIR_ON_EC2 at all."
-                ls -la
-                exit 1
-              else
-                echo "Warning: Found JAR using fallback pattern in $JAR_SOURCE_DIR_ON_EC2: $COPIED_JAR_NAME"
-              fi
+              echo "Error: JAR file matching '$JAR_FILE_PATTERN' not found in $EC2_APP_DIR after SCP."
+              ls -la "$EC2_APP_DIR"
+              exit 1
             fi
+            echo "Found JAR: $COPIED_JAR_NAME"
             
-            echo "--- Moving $COPIED_JAR_NAME to $FINAL_TARGET_JAR_PATH ---"
+            echo "--- Preparing to move $COPIED_JAR_NAME to $FINAL_TARGET_JAR_PATH ---"
+            if [ -f "$FINAL_TARGET_JAR_PATH" ]; then
+              echo "Removing existing $FINAL_TARGET_JAR_PATH"
+              rm -f "$FINAL_TARGET_JAR_PATH"
+            fi
+            echo "Moving $COPIED_JAR_NAME to $FINAL_TARGET_JAR_PATH"
             mv "$COPIED_JAR_NAME" "$FINAL_TARGET_JAR_PATH"
 
             echo "--- Restarting picobox-backend service ---"
             sudo systemctl restart picobox-backend.service
             
             echo "--- Waiting for service to start (20 seconds) ---"
-            sleep 20 # 서비스가 완전히 시작될 때까지 대기
+            sleep 20
             
             echo "--- Checking picobox-backend service status ---"
             sudo systemctl status picobox-backend.service || true 
             
-            echo "--- Tailing application log (last 30 lines) ---"
-            tail -n 30 "$EC2_HOME_DIR/app.log" || true
+            echo "--- Tailing application log (last 30 lines, if exists) ---"
+            if [ -f "$EC2_APP_DIR/app.log" ]; then
+              tail -n 30 "$EC2_APP_DIR/app.log"
+            else
+              echo "Log file $EC2_APP_DIR/app.log not found."
+            fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    // s3
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1")
     // redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     // mail sender

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
     implementation("com.oracle.database.security:oraclepki:23.8.0.25.04")
     implementation("com.oracle.database.security:osdt_cert:21.17.0.0")
     implementation("com.oracle.database.security:osdt_core:21.17.0.0")
+
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/uos/picobox/admin/controller/movie/AdminActorController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/movie/AdminActorController.java
@@ -5,14 +5,18 @@ import com.uos.picobox.domain.movie.dto.actor.ActorResponseDto;
 import com.uos.picobox.domain.movie.service.ActorService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -24,23 +28,100 @@ public class AdminActorController {
 
     private final ActorService actorService;
 
-    @Operation(summary = "배우 정보 등록", description = "새로운 배우 정보를 시스템에 등록합니다.")
+    @Operation(summary = "배우 정보 및 프로필 이미지 동시 등록",
+            description = "새로운 배우 정보(JSON 'actorDetails')와 프로필 이미지 파일('profileImage')을 한 번의 요청으로 등록합니다. (Content-Type: multipart/form-data)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "배우 정보가 성공적으로 등록되었습니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복된 배우 정보)."),
-            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+            @ApiResponse(responseCode = "201", description = "배우 정보와 이미지가 성공적으로 등록되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 배우 등)."),
+            @ApiResponse(responseCode = "500", description = "서버 오류 또는 파일 업로드 실패입니다.")
     })
-    @PostMapping("/create")
-    public ResponseEntity<ActorResponseDto> createActor(
-            @Valid @RequestBody ActorRequestDto actorRequestDto) {
-        ActorResponseDto responseDto = actorService.registerActor(actorRequestDto);
+    @PostMapping(value = "/create-with-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ActorResponseDto> createActorWithImage(
+            @Parameter(name = "actorDetails", required = true, description = "배우 상세 정보 (JSON 형식)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorRequestDto.class)))
+            @Valid @RequestPart("actorDetails") ActorRequestDto actorRequestDto,
+            @Parameter(name = "profileImage", description = "프로필 이미지 파일 (선택 사항)",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile) {
+        ActorResponseDto responseDto = actorService.registerActor(actorRequestDto, profileImageFile);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @Operation(summary = "배우 정보 등록 (메타데이터 전용)",
+            description = "새로운 배우 정보(JSON)만 시스템에 등록합니다. 프로필 이미지는 null로 설정되며, '/{actorId}/profile-image' API로 별도 업로드해야 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "배우 정보(메타데이터)가 성공적으로 등록되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 배우 등).")
+    })
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<ActorResponseDto> createActorMetadata(
+            @Valid @RequestBody ActorRequestDto actorRequestDto) {
+        ActorResponseDto responseDto = actorService.registerActor(actorRequestDto, null);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @Operation(summary = "배우 정보 및 프로필 이미지 동시 수정",
+            description = "기존 배우 정보(JSON 'actorDetails')를 수정하고, 프로필 이미지 파일('profileImage')도 함께 교체합니다. (Content-Type: multipart/form-data)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "배우 정보와 이미지가 성공적으로 수정되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 배우 등)."),
+            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류 또는 파일 업로드 실패입니다.")
+    })
+    @PutMapping(value = "/{actorId}/update-with-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ActorResponseDto> updateActorWithImage(
+            @Parameter(description = "수정할 배우 ID", required = true) @PathVariable Long actorId,
+            @Parameter(name = "actorDetails", required = true, description = "수정할 배우 상세 정보 (JSON 형식)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorRequestDto.class)))
+            @Valid @RequestPart("actorDetails") ActorRequestDto actorRequestDto,
+            @Parameter(name = "profileImage", description = "새 프로필 이미지 파일 (선택 사항, 기존 이미지 교체)",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile) {
+        ActorResponseDto updatedActor = actorService.editActor(actorId, actorRequestDto, profileImageFile);
+        return ResponseEntity.ok(updatedActor);
+    }
+
+    @Operation(summary = "배우 정보 수정 (메타데이터 전용)",
+            description = "기존 배우 정보(JSON)만 수정합니다. 프로필 이미지는 이 API로 변경되지 않으며, '/{actorId}/profile-image' API를 사용해야 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "배우 정보(메타데이터)가 성공적으로 수정되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 배우 등)."),
+            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다.")
+    })
+    @PutMapping(value = "/{actorId}", consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<ActorResponseDto> updateActorMetadata(
+            @Parameter(description = "수정할 배우 ID", required = true) @PathVariable Long actorId,
+            @Valid @RequestBody ActorRequestDto actorRequestDto) {
+        ActorResponseDto updatedActor = actorService.editActor(actorId, actorRequestDto, null);
+        return ResponseEntity.ok(updatedActor);
+    }
+
+    @Operation(summary = "배우 프로필 이미지 업로드/변경/삭제 (이미지 전용)",
+            description = "특정 배우의 프로필 이미지를 업로드하거나 변경합니다. 기존 이미지가 있으면 덮어쓰기 됩니다. 파일을 보내지 않으면 기존 이미지가 삭제되고 URL이 null로 설정됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 이미지가 성공적으로 업로드/변경/삭제되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "파일 처리 중 오류가 발생했습니다.")
+    })
+    @PutMapping(value = "/{actorId}/profile-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ActorResponseDto> uploadOrUpdateActorProfileImage(
+            @Parameter(description = "프로필 이미지를 업로드/변경/삭제할 배우 ID", required = true) @PathVariable Long actorId,
+            @Parameter(name = "profileImage", description = "프로필 이미지 파일. 파일을 보내지 않으면 기존 이미지가 삭제됩니다.",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile) {
+        ActorResponseDto actorResponseDto = actorService.uploadOrUpdateActorProfileImage(actorId, profileImageFile);
+        return ResponseEntity.ok(actorResponseDto);
     }
 
     @Operation(summary = "배우 전체 목록 조회", description = "시스템에 등록된 모든 배우 목록을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "배우 목록이 성공적으로 조회되었습니다."),
-            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+            @ApiResponse(responseCode = "200", description = "배우 목록이 성공적으로 조회되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class)))
     })
     @GetMapping("/get")
     public ResponseEntity<List<ActorResponseDto>> getAllActors() {
@@ -50,46 +131,28 @@ public class AdminActorController {
 
     @Operation(summary = "특정 배우 정보 조회", description = "ID로 특정 배우의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "배우 정보가 성공적으로 조회되었습니다."),
-            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다."),
-            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+            @ApiResponse(responseCode = "200", description = "배우 정보가 성공적으로 조회되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다.")
     })
     @GetMapping("/get/{actorId}")
     public ResponseEntity<ActorResponseDto> getActorById(
-            @Parameter(description = "조회할 배우 ID", required = true, example = "1")
-            @PathVariable Long actorId) {
+            @Parameter(description = "조회할 배우 ID", required = true) @PathVariable Long actorId) {
         ActorResponseDto actor = actorService.findActorById(actorId);
         return ResponseEntity.ok(actor);
     }
 
-    @Operation(summary = "배우 정보 수정", description = "기존 배우 정보를 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "배우 정보가 성공적으로 수정되었습니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복된 배우 정보)."),
-            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다."),
-            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
-    })
-    @PutMapping("/update/{actorId}")
-    public ResponseEntity<ActorResponseDto> updateActor(
-            @Parameter(description = "수정할 배우 ID", required = true, example = "1")
-            @PathVariable Long actorId,
-            @Valid @RequestBody ActorRequestDto actorRequestDto) {
-        ActorResponseDto updatedActor = actorService.editActor(actorId, actorRequestDto);
-        return ResponseEntity.ok(updatedActor);
-    }
-
-    @Operation(summary = "배우 정보 삭제", description = "배우 정보를 시스템에서 삭제합니다. 'force=true' 쿼리 파라미터를 사용하면 출연한 영화가 있어도 강제로 삭제합니다.")
+    @Operation(summary = "배우 정보 삭제", description = "배우 정보를 삭제합니다. S3의 프로필 이미지도 함께 삭제됩니다. 'force=true' 쿼리 파라미터를 사용하여 출연 영화가 있어도 강제 삭제할 수 있습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "배우 정보가 성공적으로 삭제되었습니다."),
-            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 해당 배우가 출연한 영화가 있어 삭제할 수 없으나 강제 삭제 옵션이 없는 경우)."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 출연 영화가 있어 삭제 불가하나 강제 옵션 미사용)."),
+            @ApiResponse(responseCode = "404", description = "해당 배우를 찾을 수 없습니다.")
     })
     @DeleteMapping("/delete/{actorId}")
     public ResponseEntity<Void> deleteActor(
-            @Parameter(description = "삭제할 배우 ID", required = true, example = "1")
-            @PathVariable Long actorId,
-            @Parameter(description = "강제 삭제 여부. 출연한 영화가 있어도 삭제하려면 true로 설정.", required = false, example = "false")
-            @RequestParam(value = "force", defaultValue = "false") boolean force) {
+            @Parameter(description = "삭제할 배우 ID", required = true) @PathVariable Long actorId,
+            @Parameter(description = "강제 삭제 여부. 출연한 영화가 있어도 삭제하려면 true로 설정.", required = false)
+            @RequestParam(defaultValue = "false") boolean force) {
         actorService.removeActor(actorId, force);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/uos/picobox/admin/controller/movie/AdminActorController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/movie/AdminActorController.java
@@ -1,5 +1,7 @@
 package com.uos.picobox.admin.controller.movie;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.uos.picobox.domain.movie.dto.actor.ActorRequestDto;
 import com.uos.picobox.domain.movie.dto.actor.ActorResponseDto;
 import com.uos.picobox.domain.movie.service.ActorService;
@@ -18,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Tag(name = "관리자 - 02. 배우 관리", description = "배우 정보 CRUD API (관리자용)")
@@ -28,22 +31,15 @@ public class AdminActorController {
 
     private final ActorService actorService;
 
-    @Operation(summary = "배우 정보 및 프로필 이미지 동시 등록",
-            description = "새로운 배우 정보(JSON 'actorDetails')와 프로필 이미지 파일('profileImage')을 한 번의 요청으로 등록합니다. (Content-Type: multipart/form-data)")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "배우 정보와 이미지가 성공적으로 등록되었습니다.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 배우 등)."),
-            @ApiResponse(responseCode = "500", description = "서버 오류 또는 파일 업로드 실패입니다.")
-    })
-    @PostMapping(value = "/create-with-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/create-with-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ActorResponseDto> createActorWithImage(
-            @Parameter(name = "actorDetails", required = true, description = "배우 상세 정보 (JSON 형식)",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ActorRequestDto.class)))
-            @Valid @RequestPart("actorDetails") ActorRequestDto actorRequestDto,
-            @Parameter(name = "profileImage", description = "프로필 이미지 파일 (선택 사항)",
-                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile) {
+            @RequestPart("actorDetails") String actorDetailsJson,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile
+    ) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        ActorRequestDto actorRequestDto = objectMapper.readValue(actorDetailsJson, ActorRequestDto.class);
+
         ActorResponseDto responseDto = actorService.registerActor(actorRequestDto, profileImageFile);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }

--- a/src/main/java/com/uos/picobox/admin/controller/movie/AdminMovieController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/movie/AdminMovieController.java
@@ -5,14 +5,18 @@ import com.uos.picobox.domain.movie.dto.movie.MovieResponseDto;
 import com.uos.picobox.domain.movie.service.MovieService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -24,20 +28,104 @@ public class AdminMovieController {
 
     private final MovieService movieService;
 
-    @Operation(summary = "영화 정보 등록", description = "새로운 영화 정보를 시스템에 등록합니다.")
+    @Operation(summary = "영화 정보 및 포스터 동시 등록",
+            description = "새로운 영화 정보(JSON 'movieDetails')와 포스터 이미지 파일('posterImage')을 한 번의 요청으로 등록합니다. Content-Type은 'multipart/form-data'여야 합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "영화 정보가 성공적으로 등록되었습니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 영화)."),
-            @ApiResponse(responseCode = "404", description = "관련 정보(배급사, 등급, 장르, 배우)를 찾을 수 없습니다.")
+            @ApiResponse(responseCode = "201", description = "영화 정보와 이미지가 성공적으로 등록되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 영화, 파일 형식 오류 등)."),
+            @ApiResponse(responseCode = "404", description = "관련 정보(배급사, 등급, 장르, 배우)를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류 또는 파일 업로드 실패입니다.")
     })
-    @PostMapping("/create")
-    public ResponseEntity<MovieResponseDto> createMovie(
-            @Valid @RequestBody MovieRequestDto requestDto) {
-        MovieResponseDto responseDto = movieService.registerMovie(requestDto);
+    @PostMapping(value = "/create-with-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<MovieResponseDto> createMovieWithImage(
+            @Parameter(name = "movieDetails", required = true, description = "영화 상세 정보 (JSON 형식)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieRequestDto.class)))
+            @Valid @RequestPart("movieDetails") MovieRequestDto requestDto,
+
+            @Parameter(name = "posterImage", description = "포스터 이미지 파일 (선택 사항)",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImageFile) {
+        MovieResponseDto responseDto = movieService.registerMovie(requestDto, posterImageFile);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
-    @Operation(summary = "영화 전체 목록 조회", description = "등록된 모든 영화 목록을 조회합니다.")
+    @Operation(summary = "영화 정보 등록 (메타데이터 전용)",
+            description = "새로운 영화 정보(JSON)만 시스템에 등록합니다. 포스터 이미지는 null로 설정되며, '/{movieId}/poster' API로 별도 업로드해야 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "영화 정보(메타데이터)가 성공적으로 등록되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 영화)."),
+            @ApiResponse(responseCode = "404", description = "관련 정보(배급사, 등급, 장르, 배우)를 찾을 수 없습니다.")
+    })
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<MovieResponseDto> createMovieMetadata(
+            @Valid @RequestBody MovieRequestDto requestDto) {
+        MovieResponseDto responseDto = movieService.registerMovie(requestDto, null);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @Operation(summary = "영화 정보 및 포스터 동시 수정",
+            description = "기존 영화 정보(JSON 'movieDetails')를 수정하고, 포스터 이미지 파일('posterImage')도 함께 교체합니다. Content-Type은 'multipart/form-data'여야 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "영화 정보와 이미지가 성공적으로 수정되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 영화, 파일 형식 오류 등)."),
+            @ApiResponse(responseCode = "404", description = "해당 영화 또는 관련 정보를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류 또는 파일 업로드 실패입니다.")
+    })
+    @PutMapping(value = "/{movieId}/update-with-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<MovieResponseDto> updateMovieWithImage(
+            @Parameter(description = "수정할 영화 ID", required = true) @PathVariable Long movieId,
+            @Parameter(name = "movieDetails", required = true, description = "수정할 영화 상세 정보 (JSON 형식)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieRequestDto.class)))
+            @Valid @RequestPart("movieDetails") MovieRequestDto requestDto,
+            @Parameter(name = "posterImage", description = "새 포스터 이미지 파일 (선택 사항, 기존 이미지 교체)",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImageFile) {
+        MovieResponseDto updatedMovie = movieService.editMovie(movieId, requestDto, posterImageFile);
+        return ResponseEntity.ok(updatedMovie);
+    }
+
+    @Operation(summary = "영화 정보 수정 (메타데이터 전용)",
+            description = "기존 영화 정보(JSON)만 수정합니다. 포스터 이미지는 이 API로 변경되지 않으며, '/{movieId}/poster' API를 사용해야 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "영화 정보(메타데이터)가 성공적으로 수정되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 영화)."),
+            @ApiResponse(responseCode = "404", description = "해당 영화를 찾을 수 없습니다.")
+    })
+    @PutMapping(value = "/{movieId}", consumes = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<MovieResponseDto> updateMovieMetadata(
+            @Parameter(description = "수정할 영화 ID", required = true) @PathVariable Long movieId,
+            @Valid @RequestBody MovieRequestDto requestDto) {
+        MovieResponseDto updatedMovie = movieService.editMovie(movieId, requestDto, null);
+        return ResponseEntity.ok(updatedMovie);
+    }
+
+    @Operation(summary = "영화 포스터 이미지 업로드/변경/삭제 (이미지 전용)",
+            description = "특정 영화의 포스터 이미지를 업로드하거나 변경합니다. 파일을 보내면 기존 이미지는 삭제 후 새 이미지로 교체됩니다. 파일을 보내지 않으면(null 또는 empty) 기존 포스터가 삭제되고 URL이 null로 설정됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "포스터 이미지가 성공적으로 업로드/변경/삭제되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 영화를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "파일 처리 중 오류가 발생했습니다.")
+    })
+    @PutMapping(value = "/{movieId}/poster", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<MovieResponseDto> uploadOrUpdateMoviePoster(
+            @Parameter(description = "포스터를 업로드/변경/삭제할 영화 ID", required = true) @PathVariable Long movieId,
+            @Parameter(name = "posterImage", description = "포스터 이미지 파일. 파일을 보내지 않으면 기존 포스터가 삭제됩니다.",
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart(value = "posterImage", required = false) MultipartFile posterImageFile) {
+        MovieResponseDto movieResponseDto = movieService.uploadMoviePoster(movieId, posterImageFile);
+        return ResponseEntity.ok(movieResponseDto);
+    }
+
+    @Operation(summary = "영화 전체 목록 조회", description = "시스템에 등록된 모든 영화 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "영화 목록이 성공적으로 조회되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class)))
+    })
     @GetMapping("/get")
     public ResponseEntity<List<MovieResponseDto>> getAllMovies() {
         List<MovieResponseDto> movies = movieService.findAllMovies();
@@ -46,42 +134,26 @@ public class AdminMovieController {
 
     @Operation(summary = "특정 영화 정보 조회", description = "ID로 특정 영화의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "영화 정보가 성공적으로 조회되었습니다."),
-            @ApiResponse(responseCode = "404", description = "해당 영화를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "200", description = "영화 정보가 성공적으로 조회되었습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = MovieResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 영화를 찾을 수 없습니다.")
     })
     @GetMapping("/get/{movieId}")
     public ResponseEntity<MovieResponseDto> getMovieById(
-            @Parameter(description = "조회할 영화 ID", required = true, example = "1")
-            @PathVariable Long movieId) {
+            @Parameter(description = "조회할 영화 ID", required = true) @PathVariable Long movieId) {
         MovieResponseDto movie = movieService.findMovieById(movieId);
         return ResponseEntity.ok(movie);
     }
 
-    @Operation(summary = "영화 정보 수정", description = "기존 영화 정보를 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "영화 정보가 성공적으로 수정되었습니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 유효성 검사 실패, 중복 영화)."),
-            @ApiResponse(responseCode = "404", description = "해당 영화 또는 관련 정보를 찾을 수 없습니다.")
-    })
-    @PutMapping("/update/{movieId}")
-    public ResponseEntity<MovieResponseDto> updateMovie(
-            @Parameter(description = "수정할 영화 ID", required = true, example = "1")
-            @PathVariable Long movieId,
-            @Valid @RequestBody MovieRequestDto requestDto) {
-        MovieResponseDto updatedMovie = movieService.editMovie(movieId, requestDto);
-        return ResponseEntity.ok(updatedMovie);
-    }
-
-    @Operation(summary = "영화 정보 삭제", description = "영화 정보를 시스템에서 삭제합니다.")
+    @Operation(summary = "영화 정보 삭제", description = "영화 정보를 시스템에서 삭제합니다. S3의 포스터 이미지도 함께 삭제됩니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "영화 정보가 성공적으로 삭제되었습니다."),
             @ApiResponse(responseCode = "404", description = "해당 영화를 찾을 수 없습니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 상영 중인 영화).")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (예: 상영 스케줄이 있는 영화 등).")
     })
     @DeleteMapping("/delete/{movieId}")
     public ResponseEntity<Void> deleteMovie(
-            @Parameter(description = "삭제할 영화 ID", required = true, example = "1")
-            @PathVariable Long movieId) {
+            @Parameter(description = "삭제할 영화 ID", required = true) @PathVariable Long movieId) {
         movieService.removeMovie(movieId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/uos/picobox/domain/movie/dto/actor/ActorRequestDto.java
+++ b/src/main/java/com/uos/picobox/domain/movie/dto/actor/ActorRequestDto.java
@@ -2,11 +2,14 @@ package com.uos.picobox.domain.movie.dto.actor;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -18,9 +21,8 @@ public class ActorRequestDto {
     @Schema(description = "배우 이름", example = "송강호", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "생년월일은 yyyy-MM-dd 형식으로 입력해주세요.")
     @Schema(description = "생년월일 (yyyy-MM-dd)", example = "1967-01-17", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private String birthDate; // Service에서 LocalDate로 변환
+    private LocalDate birthDate;
 
     @Schema(description = "배우 소개", example = "배우입니다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String biography;

--- a/src/main/java/com/uos/picobox/domain/movie/dto/actor/ActorResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/movie/dto/actor/ActorResponseDto.java
@@ -23,10 +23,14 @@ public class ActorResponseDto {
     @Schema(description = "배우 소개", example = "배우입니다.")
     private String biography;
 
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImageUrl;
+
     public ActorResponseDto(Actor actor) {
         this.actorId = actor.getId();
         this.name = actor.getName();
         this.birthDate = actor.getBirthDate();
         this.biography = actor.getBiography();
+        this.profileImageUrl = actor.getProfileImageUrl();
     }
 }

--- a/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieResponseDto.java
@@ -49,6 +49,9 @@ public class MovieResponseDto {
     @Schema(description = "출연진 목록")
     private List<MovieCastMemberResponseDto> movieCasts;
 
+    @Schema(description = "포스터 이미지 URL")
+    private String posterUrl;
+
     // MovieCast 정보를 담기 위한 내부 DTO
     @Getter
     public static class MovieCastMemberResponseDto {
@@ -89,6 +92,7 @@ public class MovieResponseDto {
         this.director = movie.getDirector();
         this.distributor = new DistributorResponseDto(movie.getDistributor());
         this.movieRating = new MovieRatingResponseDto(movie.getMovieRating());
+        this.posterUrl = movie.getPosterUrl();
 
         this.genres = movie.getGenreMappings().stream()
                 .map(mapping -> new MovieGenreResponseDto(mapping.getMovieGenre()))

--- a/src/main/java/com/uos/picobox/domain/movie/entity/Actor.java
+++ b/src/main/java/com/uos/picobox/domain/movie/entity/Actor.java
@@ -28,16 +28,24 @@ public class Actor {
     @Column(name = "BIOGRAPHY", length = 1000)
     private String biography;
 
+    @Column(name = "PROFILE_IMAGE_URL", length = 500)
+    private String profileImageUrl;
+
     @Builder
-    public Actor(String name, LocalDate birthDate, String biography) {
+    public Actor(String name, LocalDate birthDate, String biography, String profileImageUrl) {
         this.name = name;
         this.birthDate = birthDate;
         this.biography = biography;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public void updateDetails(String name, LocalDate birthDate, String biography) {
         this.name = name;
         this.birthDate = birthDate;
         this.biography = biography;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/uos/picobox/domain/movie/entity/Movie.java
+++ b/src/main/java/com/uos/picobox/domain/movie/entity/Movie.java
@@ -49,6 +49,9 @@ public class Movie {
     @JoinColumn(name = "RATING_ID", nullable = false)
     private MovieRating movieRating;
 
+    @Column(name = "POSTER_URL", length = 500)
+    private String posterUrl;
+
     //cascade = CascadeType.ALL, orphanRemoval = true: Movie가 저장/삭제될 때 매핑 정보도 함께 처리
     @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<MovieGenreMapping> genreMappings = new HashSet<>();
@@ -58,7 +61,7 @@ public class Movie {
 
     @Builder
     public Movie(String title, String description, Integer duration, LocalDate releaseDate,
-                 String language, String director, Distributor distributor, MovieRating movieRating) {
+                 String language, String director, Distributor distributor, MovieRating movieRating, String posterUrl) {
         this.title = title;
         this.description = description;
         this.duration = duration;
@@ -67,6 +70,7 @@ public class Movie {
         this.director = director;
         this.distributor = distributor;
         this.movieRating = movieRating;
+        this.posterUrl = posterUrl;
     }
 
     public void updateDetails(String title, String description, Integer duration, LocalDate releaseDate,
@@ -79,6 +83,10 @@ public class Movie {
         this.director = director;
         this.distributor = distributor;
         this.movieRating = movieRating;
+    }
+
+    public void updatePosterUrl(String posterUrl) {
+        this.posterUrl = posterUrl;
     }
 
     // 연관관계 편의 메소드 (장르)

--- a/src/main/java/com/uos/picobox/domain/movie/service/ActorService.java
+++ b/src/main/java/com/uos/picobox/domain/movie/service/ActorService.java
@@ -4,6 +4,7 @@ import com.uos.picobox.domain.movie.dto.actor.ActorRequestDto;
 import com.uos.picobox.domain.movie.dto.actor.ActorResponseDto;
 import com.uos.picobox.domain.movie.entity.Actor;
 import com.uos.picobox.domain.movie.repository.ActorRepository;
+import com.uos.picobox.global.service.S3Service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,10 +12,12 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
 
+
+import java.io.IOException;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,28 +28,11 @@ import java.util.stream.Collectors;
 public class ActorService {
 
     private final ActorRepository actorRepository;
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
-
-    /**
-     * 문자열 형식의 생년월일을 LocalDate 객체로 변환합니다.
-     * @param birthDateStr yyyy-MM-dd 형식의 생년월일 문자열
-     * @return 변환된 LocalDate 객체, 또는 입력 문자열이 비어있거나 null이면 null
-     * @throws IllegalArgumentException 날짜 형식이 올바르지 않을 경우
-     */
-    private LocalDate parseBirthDate(String birthDateStr) {
-        if (StringUtils.hasText(birthDateStr)) {
-            try {
-                return LocalDate.parse(birthDateStr, DATE_FORMATTER);
-            } catch (DateTimeParseException e) {
-                throw new IllegalArgumentException("생년월일 형식이 올바르지 않습니다 (yyyy-MM-dd): " + birthDateStr, e);
-            }
-        }
-        return null;
-    }
+    private final S3Service s3Service; // S3Service 주입
 
     @Transactional
-    public ActorResponseDto registerActor(ActorRequestDto actorRequestDto) {
-        LocalDate birthDate = parseBirthDate(actorRequestDto.getBirthDate());
+    public ActorResponseDto registerActor(ActorRequestDto actorRequestDto, MultipartFile profileImageFile) {
+        LocalDate birthDate = actorRequestDto.getBirthDate();
 
         if (birthDate != null) {
             actorRepository.findByNameAndBirthDate(actorRequestDto.getName(), birthDate)
@@ -55,13 +41,137 @@ public class ActorService {
                     });
         }
 
+        String profileS3Url = null;
+        if (profileImageFile != null && !profileImageFile.isEmpty()) {
+            try {
+                profileS3Url = s3Service.upload(profileImageFile, "actor-profiles");
+            } catch (IOException | SdkException e) {
+                log.error("ActorService: 프로필 이미지 업로드 실패.", e);
+                throw new RuntimeException("프로필 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+            }
+        }
+
         Actor actor = Actor.builder()
                 .name(actorRequestDto.getName())
                 .birthDate(birthDate)
                 .biography(actorRequestDto.getBiography())
+                .profileImageUrl(profileS3Url)
                 .build();
         Actor savedActor = actorRepository.save(actor);
         return new ActorResponseDto(savedActor);
+    }
+
+    @Transactional
+    public ActorResponseDto editActor(Long actorId, ActorRequestDto actorRequestDto, MultipartFile profileImageFile) {
+        Actor actor = actorRepository.findById(actorId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 배우를 찾을 수 없습니다: " + actorId));
+
+        LocalDate newBirthDate = actorRequestDto.getBirthDate();
+
+        boolean nameChanged = !actor.getName().equals(actorRequestDto.getName());
+        boolean birthDateChanged = actor.getBirthDate() == null && newBirthDate != null || actor.getBirthDate() != null && !actor.getBirthDate().equals(newBirthDate);
+
+        if ((nameChanged || birthDateChanged) && newBirthDate != null) {
+            actorRepository.findByNameAndBirthDate(actorRequestDto.getName(), newBirthDate)
+                    .filter(existingActor -> !existingActor.getId().equals(actorId))
+                    .ifPresent(a -> {
+                        throw new IllegalArgumentException("수정하려는 이름과 생년월일이 다른 배우와 중복됩니다.");
+                    });
+        }
+
+        actor.updateDetails(
+                actorRequestDto.getName(),
+                newBirthDate,
+                actorRequestDto.getBiography()
+        );
+
+        String currentProfileImageUrl = actor.getProfileImageUrl();
+        String finalProfileS3Url = currentProfileImageUrl;
+
+        if (profileImageFile != null && !profileImageFile.isEmpty()) {
+            if (StringUtils.hasText(currentProfileImageUrl)) {
+                try {
+                    s3Service.delete(currentProfileImageUrl);
+                } catch (Exception e) {
+                    log.warn("기존 프로필 이미지 S3 삭제 중 오류 발생 (무시하고 진행): " + e.getMessage());
+                }
+            }
+            try {
+                finalProfileS3Url = s3Service.upload(profileImageFile, "actor-profiles");
+            } catch (IOException | SdkException e) {
+                log.error("ActorService: 프로필 이미지 수정 업로드 실패.", e);
+                throw new RuntimeException("프로필 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+            }
+        }
+        actor.updateProfileImageUrl(finalProfileS3Url);
+
+        actorRepository.save(actor);
+        return new ActorResponseDto(actor);
+    }
+
+    /**
+     * 특정 배우의 프로필 이미지만 업로드/변경 또는 삭제합니다.
+     * 파일이 제공되면 업로드/변경하고, 파일이 제공되지 않으면 기존 이미지를 삭제하고 URL을 null로 설정합니다.
+     */
+    @Transactional
+    public ActorResponseDto uploadOrUpdateActorProfileImage(Long actorId, MultipartFile profileImageFile) {
+        Actor actor = actorRepository.findById(actorId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 배우를 찾을 수 없습니다: " + actorId));
+
+        String newProfileS3Url = null;
+
+        if (StringUtils.hasText(actor.getProfileImageUrl())) {
+            try {
+                s3Service.delete(actor.getProfileImageUrl());
+            } catch (Exception e) {
+                log.warn("프로필 이미지 변경/삭제 시 기존 S3 이미지 삭제 중 오류 발생 (무시하고 진행): " + e.getMessage());
+            }
+        }
+
+        if (profileImageFile != null && !profileImageFile.isEmpty()) {
+            try {
+                newProfileS3Url = s3Service.upload(profileImageFile, "actor-profiles");
+            } catch (IOException | SdkException e) {
+                log.error("ActorService: 프로필 이미지 전용 업로드 실패 (actorId: {}).", actorId, e);
+                throw new RuntimeException("프로필 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+            }
+        }
+
+        actor.updateProfileImageUrl(newProfileS3Url);
+        actorRepository.save(actor);
+        return new ActorResponseDto(actor);
+    }
+
+    @Transactional
+    public void removeActor(Long actorId, boolean force) {
+        Actor actor = actorRepository.findById(actorId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 배우를 찾을 수 없습니다: " + actorId));
+
+        if (!force) {
+            List<String> associatedMovies = actorRepository.findMovieTitlesByActorId(actorId);
+            if (!associatedMovies.isEmpty()) {
+                String movies = String.join(", ", associatedMovies);
+                throw new IllegalArgumentException(
+                        String.format("해당 배우가 출연한 영화가 있어 삭제할 수 없습니다. (배우 ID: %d, 영화: [%s]). 강제 삭제를 원하시면 'force=true' 파라미터를 사용하세요.", actorId, movies)
+                );
+            }
+        }
+
+        if (StringUtils.hasText(actor.getProfileImageUrl())) {
+            try {
+                s3Service.delete(actor.getProfileImageUrl());
+            } catch (Exception e) {
+                log.warn("배우 삭제 중 S3 프로필 이미지 삭제 실패 (무시하고 진행): " + e.getMessage());
+            }
+        }
+
+        try {
+            actorRepository.delete(actor);
+            log.info("배우 정보가 성공적으로 삭제되었습니다. ID: {}, 강제삭제: {}", actorId, force);
+        } catch (DataIntegrityViolationException e) {
+            log.error("배우 삭제 중 예상치 못한 DataIntegrityViolationException 발생 (ID: {}): {}", actorId, e.getMessage());
+            throw new IllegalStateException("배우 삭제 중 데이터 무결성 문제가 발생했습니다. (ID: " + actorId + ")", e);
+        }
     }
 
     public List<ActorResponseDto> findAllActors() {
@@ -74,63 +184,5 @@ public class ActorService {
         Actor actor = actorRepository.findById(actorId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 배우를 찾을 수 없습니다: " + actorId));
         return new ActorResponseDto(actor);
-    }
-
-    @Transactional
-    public ActorResponseDto editActor(Long actorId, ActorRequestDto actorRequestDto) {
-        Actor actor = actorRepository.findById(actorId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 배우를 찾을 수 없습니다: " + actorId));
-
-        LocalDate newBirthDate = parseBirthDate(actorRequestDto.getBirthDate());
-
-        boolean nameChanged = !actor.getName().equals(actorRequestDto.getName());
-        boolean birthDateChanged = (actor.getBirthDate() == null && newBirthDate != null) ||
-                (actor.getBirthDate() != null && !actor.getBirthDate().equals(newBirthDate));
-
-        if ((nameChanged || birthDateChanged) && newBirthDate != null) {
-            actorRepository.findByNameAndBirthDate(actorRequestDto.getName(), newBirthDate)
-                    .filter(existingActor -> !existingActor.getId().equals(actorId))
-                    .ifPresent(a -> {
-                        throw new IllegalArgumentException("수정하려는 이름과 생년월일이 다른 배우와 중복됩니다.");
-                    });
-        }
-
-        actor.updateDetails(actorRequestDto.getName(), newBirthDate, actorRequestDto.getBiography());
-        return new ActorResponseDto(actor);
-    }
-
-    /**
-     * 배우 정보를 삭제합니다.
-     * 이 배우가 출연한 영화가 있다면, 관련 영화 제목 목록과 함께 예외를 발생시킵니다.
-     * 강제 삭제 파라미터(force)가 true이면, 관련 영화가 있어도 삭제를 진행합니다 (ON DELETE CASCADE).
-     * @param actorId 삭제할 배우 ID
-     * @param force 강제 삭제 여부 (true이면 출연 영화가 있어도 삭제)
-     * @throws EntityNotFoundException 해당 ID의 배우가 없을 경우
-     * @throws IllegalArgumentException 배우가 출연 영화가 있고 force=false일 경우
-     * @throws DataIntegrityViolationException DB 레벨의 다른 무결성 제약 조건 위반 시
-     */
-    @Transactional
-    public void removeActor(Long actorId, boolean force) {
-        Actor actor = actorRepository.findById(actorId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 배우를 찾을 수 없습니다: " + actorId));
-
-        List<String> associatedMovies = actorRepository.findMovieTitlesByActorId(actorId);
-
-        if (!associatedMovies.isEmpty() && !force) {
-            String movies = String.join(", ", associatedMovies);
-            throw new IllegalArgumentException(
-                    String.format("해당 배우가 출연한 영화가 있어 삭제할 수 없습니다. (배우 ID: %d, 영화: [%s]). 강제 삭제를 원하시면 'force=true' 파라미터를 사용하세요.", actorId, movies)
-            );
-        }
-
-        // force가 true이거나, associatedMovies가 비어있으면 삭제 진행
-        // ON DELETE CASCADE에 의해 MOVIE_CAST 테이블의 관련 레코드는 자동으로 삭제됩니다.
-        try {
-            actorRepository.delete(actor);
-            log.info("배우 정보가 성공적으로 삭제되었습니다. ID: {}, 강제삭제: {}", actorId, force);
-        } catch (DataIntegrityViolationException e) {
-            log.error("배우 삭제 중 예상치 못한 DataIntegrityViolationException 발생 (ID: {}): {}", actorId, e.getMessage());
-            throw new IllegalStateException("배우 삭제 중 데이터 무결성 문제가 발생했습니다. (ID: " + actorId + ")", e);
-        }
     }
 }

--- a/src/main/java/com/uos/picobox/domain/movie/service/MovieService.java
+++ b/src/main/java/com/uos/picobox/domain/movie/service/MovieService.java
@@ -4,17 +4,23 @@ import com.uos.picobox.domain.movie.dto.movie.MovieRequestDto;
 import com.uos.picobox.domain.movie.dto.movie.MovieResponseDto;
 import com.uos.picobox.domain.movie.entity.*;
 import com.uos.picobox.domain.movie.repository.*;
+import com.uos.picobox.global.service.S3Service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
 
+import java.io.IOException;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -25,11 +31,10 @@ public class MovieService {
     private final MovieRatingRepository movieRatingRepository;
     private final MovieGenreRepository movieGenreRepository;
     private final ActorRepository actorRepository;
-
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE; // yyyy-MM-dd
+    private final S3Service s3Service;
 
     @Transactional
-    public MovieResponseDto registerMovie(MovieRequestDto requestDto) {
+    public MovieResponseDto registerMovie(MovieRequestDto requestDto, MultipartFile posterImageFile) {
         LocalDate releaseDate = requestDto.getReleaseDate();
 
         movieRepository.findByTitleAndReleaseDate(requestDto.getTitle(), releaseDate)
@@ -42,6 +47,16 @@ public class MovieService {
         MovieRating movieRating = movieRatingRepository.findById(requestDto.getMovieRatingId())
                 .orElseThrow(() -> new EntityNotFoundException("영화 등급을 찾을 수 없습니다: ID " + requestDto.getMovieRatingId()));
 
+        String posterS3Url = null;
+        if (posterImageFile != null && !posterImageFile.isEmpty()) {
+            try {
+                posterS3Url = s3Service.upload(posterImageFile, "movie-posters");
+            } catch (IOException | SdkException e) {
+                log.error("MovieService: 포스터 이미지 업로드 실패.", e);
+                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+            }
+        }
+
         Movie movie = Movie.builder()
                 .title(requestDto.getTitle())
                 .description(requestDto.getDescription())
@@ -51,6 +66,7 @@ public class MovieService {
                 .director(requestDto.getDirector())
                 .distributor(distributor)
                 .movieRating(movieRating)
+                .posterUrl(posterS3Url)
                 .build();
 
         // 장르 매핑 처리
@@ -88,7 +104,7 @@ public class MovieService {
     }
 
     @Transactional
-    public MovieResponseDto editMovie(Long movieId, MovieRequestDto requestDto) {
+    public MovieResponseDto editMovie(Long movieId, MovieRequestDto requestDto, MultipartFile posterImageFile) {
         Movie movie = movieRepository.findById(movieId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
 
@@ -119,7 +135,27 @@ public class MovieService {
                 movieRating
         );
 
-        // 장르 매핑 업데이트 (기존 매핑 모두 삭제 후 새로 추가)
+        String currentPosterUrl = movie.getPosterUrl();
+        String finalPosterS3Url = currentPosterUrl;
+
+        if (posterImageFile != null && !posterImageFile.isEmpty()) {
+            if (StringUtils.hasText(currentPosterUrl)) {
+                try {
+                    s3Service.delete(currentPosterUrl);
+                } catch (Exception e) {
+                    log.warn("기존 포스터 이미지 S3 삭제 중 오류 발생 (무시하고 진행): " + e.getMessage());
+                }
+            }
+            try {
+                finalPosterS3Url = s3Service.upload(posterImageFile, "movie-posters");
+            } catch (IOException | SdkException e) {
+                log.error("MovieService: 포스터 이미지 수정 업로드 실패.", e);
+                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+            }
+        }
+        movie.updatePosterUrl(finalPosterS3Url);
+
+        // 장르 매핑 업데이트
         movie.clearGenreMappings();
         if (!CollectionUtils.isEmpty(requestDto.getGenreIds())) {
             requestDto.getGenreIds().forEach(genreId -> {
@@ -129,7 +165,7 @@ public class MovieService {
             });
         }
 
-        // 출연진 매핑 업데이트 (기존 매핑 모두 삭제 후 새로 추가)
+        // 출연진 매핑 업데이트
         movie.clearMovieCasts();
         if (!CollectionUtils.isEmpty(requestDto.getMovieCasts())) {
             requestDto.getMovieCasts().forEach(castDto -> {
@@ -139,15 +175,51 @@ public class MovieService {
             });
         }
 
-        Movie updatedMovie = movieRepository.save(movie);
-        return new MovieResponseDto(updatedMovie);
+        movieRepository.save(movie);
+        return new MovieResponseDto(movie);
+    }
+
+    @Transactional
+    public MovieResponseDto uploadMoviePoster(Long movieId, MultipartFile posterImageFile) {
+        Movie movie = movieRepository.findById(movieId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
+
+        String newPosterS3Url = null;
+
+        if (StringUtils.hasText(movie.getPosterUrl())) {
+            try {
+                s3Service.delete(movie.getPosterUrl());
+            } catch (Exception e) {
+                log.warn("포스터 변경/삭제 시 기존 S3 이미지 삭제 중 오류 발생 (무시하고 진행): " + e.getMessage());
+            }
+        }
+
+        if (posterImageFile != null && !posterImageFile.isEmpty()) {
+            try {
+                newPosterS3Url = s3Service.upload(posterImageFile, "movie-posters");
+            } catch (IOException | SdkException e) {
+                log.error("MovieService: 포스터 이미지 업로드 실패 (movieId: {}).", movieId, e);
+                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+            }
+        }
+
+        movie.updatePosterUrl(newPosterS3Url);
+        movieRepository.save(movie);
+        return new MovieResponseDto(movie);
     }
 
     @Transactional
     public void removeMovie(Long movieId) {
-        if (!movieRepository.existsById(movieId)) {
-            throw new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId);
+        Movie movie = movieRepository.findById(movieId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
+
+        if (StringUtils.hasText(movie.getPosterUrl())) {
+            try {
+                s3Service.delete(movie.getPosterUrl());
+            } catch (Exception e) {
+                log.warn("영화 삭제 중 S3 포스터 이미지 삭제 실패 (무시하고 진행): " + e.getMessage());
+            }
         }
-        movieRepository.deleteById(movieId);
+        movieRepository.delete(movie);
     }
 }

--- a/src/main/java/com/uos/picobox/global/config/SecurityConfig.java
+++ b/src/main/java/com/uos/picobox/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
             "/health",
             "/swagger-ui/**",
             "/v3/api-docs/**",
+            "/swagger/**",
             "/error",
             "/api/**"
     };

--- a/src/main/java/com/uos/picobox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/uos/picobox/global/exception/GlobalExceptionHandler.java
@@ -11,7 +11,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,29 +80,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-
-    // DataIntegrityViolationException 처리 (FK 제약 조건 위반 등)
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex,
-                                                                      WebRequest request) {
-        String requestPath = request.getDescription(false).replace("uri=", "");
-        String message = "데이터 무결성 제약 조건 위반입니다. 요청을 확인해주세요.";
-        if (ex.getCause() != null && ex.getCause().getMessage() != null) {
-            if (ex.getCause().getMessage().contains("ORA-02292")) { // Oracle FK 위반
-                message = "다른 데이터에서 참조하고 있어 작업을 완료할 수 없습니다. (예: 하위 레코드가 존재함)";
-            }
-            // 다른 DB 에러 코드에 대한 처리 추가 가능
-        }
-        log.warn("Data integrity violation for request path [{}]: {}", requestPath, ex.getMessage());
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.BAD_REQUEST,
-                message,
-                requestPath
-        );
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
-
     // @Validated 유효성 검사 실패 시
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<ErrorResponse> handleHandlerMethodValidation(HandlerMethodValidationException ex,
@@ -118,6 +100,28 @@ public class GlobalExceptionHandler {
                 HttpStatus.BAD_REQUEST,
                 "입력값 유효성 검사에 실패했습니다.",
                 errors,
+                requestPath
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    // DataIntegrityViolationException 처리 (FK 제약 조건 위반 등)
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException ex,
+                                                                      WebRequest request) {
+        String requestPath = request.getDescription(false).replace("uri=", "");
+        String message = "데이터 무결성 제약 조건 위반입니다. 요청을 확인해주세요.";
+        if (ex.getCause() != null && ex.getCause().getMessage() != null) {
+            if (ex.getCause().getMessage().contains("ORA-02292")) { // Oracle FK 위반
+                message = "다른 데이터에서 참조하고 있어 작업을 완료할 수 없습니다. (예: 하위 레코드가 존재함)";
+            }
+            // 다른 DB 에러 코드에 대한 처리 추가 가능
+        }
+        log.warn("Data integrity violation for request path [{}]: {}", requestPath, ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                message,
                 requestPath
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
@@ -151,6 +155,68 @@ public class GlobalExceptionHandler {
                 requestPath
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    // 파일 업로드 크기 초과 예외 처리
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException ex, WebRequest request) {
+        String requestPath = request.getDescription(false).replace("uri=", "");
+        log.warn("Max upload size exceeded for request path [{}]: {}", requestPath, ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.PAYLOAD_TOO_LARGE,
+                "업로드 파일 크기가 너무 큽니다.",
+                requestPath);
+        return new ResponseEntity<>(errorResponse, HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+
+    // 파일 처리 관련 IOException (S3 업로드/다운로드 중 파일 스트림 오류 등)
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<ErrorResponse> handleIOException(IOException ex, WebRequest request) {
+        String requestPath = request.getDescription(false).replace("uri=", "");
+        log.error("IOException occurred for request path [{}]: {}", requestPath, ex.getMessage(), ex);
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "파일 처리 중 오류가 발생했습니다. 다시 시도해주세요.",
+                requestPath
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // AWS S3 관련 예외 처리 (S3 서비스에서 직접 발생하는 예외)
+    @ExceptionHandler(S3Exception.class)
+    public ResponseEntity<ErrorResponse> handleS3Exception(S3Exception ex, WebRequest request) {
+        String requestPath = request.getDescription(false).replace("uri=", "");
+        log.error("S3Exception for request path [{}]: {} (Status Code: {}, AWS Error Code: {})",
+                requestPath, ex.getMessage(), ex.statusCode(), ex.awsErrorDetails().errorCode(), ex);
+
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        String message = "S3 서비스 처리 중 오류가 발생했습니다.";
+
+        if (ex.statusCode() == 403) {
+            status = HttpStatus.FORBIDDEN;
+            message = "S3 서비스 접근 권한이 없습니다. 설정을 확인해주세요.";
+        } else if (ex.statusCode() == 404) {
+            status = HttpStatus.NOT_FOUND;
+            message = "S3 서비스에서 요청한 리소스를 찾을 수 없습니다 (예: 버킷 또는 객체).";
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(status, message, requestPath);
+        return new ResponseEntity<>(errorResponse, status);
+    }
+
+    // AWS SDK 일반 예외 처리
+    @ExceptionHandler(SdkException.class)
+    public ResponseEntity<ErrorResponse> handleSdkException(SdkException ex, WebRequest request) {
+        String requestPath = request.getDescription(false).replace("uri=", "");
+        log.error("AWS SDK SdkException for request path [{}]: {}", requestPath, ex.getMessage(), ex);
+
+        String message = "외부 서비스(AWS) 통신 중 오류가 발생했습니다.";
+        if (ex instanceof SdkClientException) {
+            message = "외부 서비스(AWS) 통신 중 클라이언트 측 오류(예: 네트워크)가 발생했습니다.";
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.SERVICE_UNAVAILABLE, message, requestPath);
+        return new ResponseEntity<>(errorResponse, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     // 기타 모든 처리되지 않은 예외

--- a/src/main/java/com/uos/picobox/global/service/S3Service.java
+++ b/src/main/java/com/uos/picobox/global/service/S3Service.java
@@ -1,0 +1,133 @@
+package com.uos.picobox.global.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    /**
+     * 파일을 S3에 업로드하고 해당 파일의 전체 URL을 반환합니다.
+     * @param file 업로드할 파일
+     * @param directoryPath S3 버킷 내 저장할 디렉토리 경로 (예: "movie-posters")
+     * @return 업로드된 파일의 전체 S3 URL
+     * @throws IOException 파일 처리 중 오류 발생 시
+     * @throws S3Exception S3 업로드 실패 시 SDK에서 발생하는 예외
+     * @throws SdkException S3 업로드 실패 시 SDK에서 발생하는 일반 예외
+     */
+    public String upload(MultipartFile file, String directoryPath) throws IOException {
+        if (file == null || file.isEmpty()) {
+            log.warn("업로드할 파일이 비어있습니다.");
+            return null;
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        String uniqueFileName = UUID.randomUUID().toString() + extension;
+        String s3Key = directoryPath + "/" + uniqueFileName;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .contentType(file.getContentType())
+                .build();
+
+        try {
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            // 업로드된 객체의 URL 가져오기
+            GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+            String fileUrl = s3Client.utilities().getUrl(getUrlRequest).toString();
+
+            log.info("S3 파일 업로드 성공: Key = {}, URL = {}", s3Key, fileUrl);
+            return fileUrl;
+        } catch (S3Exception e) { // S3 서비스 관련 예외
+            log.error("S3 업로드 중 S3Exception 발생: {}", e.getMessage(), e);
+            throw e;
+        } catch (SdkException e) { // AWS SDK 일반 예외 (네트워크 오류 등)
+            log.error("S3 업로드 중 SdkException 발생: {}", e.getMessage(), e);
+            throw e;
+        } catch (IOException e) { // 파일 스트림 오류
+            log.error("S3 업로드 중 IOException 발생 (파일 스트림 오류): {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * S3에서 파일을 삭제합니다.
+     * @param fileUrl 삭제할 파일의 전체 S3 URL
+     */
+    public void delete(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            log.warn("삭제할 S3 파일 URL이 비어있습니다.");
+            return;
+        }
+
+        try {
+            String objectKey = extractObjectKeyFromUrl(fileUrl);
+            if (objectKey == null) {
+                log.warn("유효하지 않은 S3 URL이거나 객체 키를 추출할 수 없습니다: {}", fileUrl);
+                return;
+            }
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectKey)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제 성공: Key = {}", objectKey);
+        } catch (S3Exception e) {
+            log.error("S3 파일 삭제 중 S3Exception 발생 (URL: {}): {}", fileUrl, e.getMessage(), e);
+        } catch (SdkException e) {
+            log.error("S3 파일 삭제 중 SdkException 발생 (URL: {}): {}", fileUrl, e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("S3 파일 URL 파싱 또는 삭제 중 예외 발생 (URL: {}): {}", fileUrl, e.getMessage(), e);
+        }
+    }
+
+    private String extractObjectKeyFromUrl(String fileUrl) {
+        try {
+            java.net.URL url = new java.net.URL(fileUrl);
+            String path = url.getPath();
+            String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+            String keyPrefix = "/" + bucketName + "/";
+            if (decodedPath.startsWith(keyPrefix)) {
+                return decodedPath.substring(keyPrefix.length());
+            } else if (decodedPath.startsWith("/")) {
+                return decodedPath.substring(1);
+            }
+            return decodedPath;
+        } catch (Exception e) {
+            log.error("S3 URL에서 객체 키 추출 실패: {}", fileUrl, e);
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,9 +48,13 @@ spring:
       credentials:
         access-key: ${AWS_ACCESS_KEY_ID}
         secret-key: ${AWS_SECRET_ACCESS_KEY}
-
 springdoc:
   override-with-generic-response: false
   swagger-ui:
     tags-sorter: alpha
     operations-sorter: method
+    urls:
+      - name: Java Annotations API
+        url: /v3/api-docs
+      - name: Custom OpenAPI YAML
+        url: /swagger/openapi.yaml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,21 @@ spring:
           starttls:
             enable: true
             required: true
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 100MB
+
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: picobox-bucket
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
 
 springdoc:
   override-with-generic-response: false

--- a/src/main/resources/static/swagger/openapi.yaml
+++ b/src/main/resources/static/swagger/openapi.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.1
+info:
+  title: BE_Picobox
+  version: 1.0.0
+
+tags:
+  - name: 관리자 - 02. 배우 관리
+    description: 배우 정보 CRUD API (관리자용)
+
+paths:
+  /api/admin/actors/create-with-image:
+    post:
+      tags:
+        - 관리자 - 02. 배우 관리
+      summary: 배우 정보 및 프로필 이미지 동시 등록
+      description: |
+        새로운 배우 정보(JSON 'actorDetails')와 프로필 이미지 파일('profileImage')을
+        한 번의 요청으로 등록합니다.
+        Content-Type: multipart/form-data
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                actorDetails:
+                  type: string
+                  description: JSON string of ActorRequestDto (as raw text, not file)
+                  example: |
+                    {
+                      "name": "정우성",
+                      "birthDate": "1972-04-22",
+                      "biography": "대한민국 배우입니다."
+                    }
+                profileImage:
+                  type: string
+                  format: binary
+                  description: 프로필 이미지 파일 (선택 사항)
+      responses:
+        '201':
+          description: 배우 정보와 이미지가 성공적으로 등록되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActorResponseDto'
+        '400':
+          description: |
+            잘못된 요청입니다 (예: 유효성 검사 실패, 중복 배우 등)
+        '500':
+          description: 서버 오류 또는 파일 업로드 실패입니다.
+
+components:
+  schemas:
+    ActorResponseDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        birthDate:
+          type: string
+          format: date
+        bio:
+          type: string
+        profileImageUrl:
+          type: string
+          format: uri


### PR DESCRIPTION
- Movie, Actor 엔티티에 이미지 URL 필드 추가 (posterUrl, profileImageUrl)
- S3Service 구현
- MovieService, ActorService 수정:
  - 엔티티 생성/수정 시 이미지 파일(MultipartFile) 선택적 처리 로직 추가
  - S3 이미지 업로드 및 기존 이미지 삭제 로직 연동
  - 엔티티 삭제 시 S3 연관 이미지 삭제 로직 추가
  - 이미지 전용 업로드/수정/삭제 서비스 메소드 추가
- AdminMovieController, AdminActorController 수정:
  - 정보 생성/수정 시 두 가지 방식 지원:
    1. 메타데이터(JSON)와 이미지 파일(multipart) 동시 처리 엔드포인트
    2. 메타데이터(JSON)만 처리하는 엔드포인트
  - 특정 엔티티의 이미지만 업로드/변경/삭제하는 전용 엔드포인트 추가
- GlobalExceptionHandler에 S3Exception, 파일 처리 관련 예외 추가
- delpoy.yml 수정: .env git secret에서 주입