### PR TITLE
[feat] 사용자 대상 영화 목록, 상세 정보 및 상영 스케줄 조회 API 구현

### DIFF
--- a/src/main/java/com/uos/picobox/admin/controller/movie/AdminMovieController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/movie/AdminMovieController.java
@@ -158,7 +158,7 @@ public class AdminMovieController {
     })
     @GetMapping("/get")
     public ResponseEntity<List<MovieResponseDto>> getAllMovies() {
-        List<MovieResponseDto> movies = movieService.findAllMovies();
+        List<MovieResponseDto> movies = movieService.findAllMoviesForAdmin();
         return ResponseEntity.ok(movies);
     }
 
@@ -171,7 +171,7 @@ public class AdminMovieController {
     @GetMapping("/get/{movieId}")
     public ResponseEntity<MovieResponseDto> getMovieById(
             @Parameter(description = "조회할 영화 ID", required = true) @PathVariable Long movieId) {
-        MovieResponseDto movie = movieService.findMovieById(movieId);
+        MovieResponseDto movie = movieService.getMovieDetail(movieId);
         return ResponseEntity.ok(movie);
     }
 

--- a/src/main/java/com/uos/picobox/client/controller/movie/MovieClientController.java
+++ b/src/main/java/com/uos/picobox/client/controller/movie/MovieClientController.java
@@ -1,0 +1,48 @@
+package com.uos.picobox.client.controller.movie;
+
+import com.uos.picobox.domain.movie.dto.movie.MovieListItemDto;
+import com.uos.picobox.domain.movie.dto.movie.MovieResponseDto;
+import com.uos.picobox.domain.movie.service.MovieService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "사용자 - 영화 정보 조회", description = "사용자 대상 영화 목록 및 상세 정보 조회 API")
+@RestController
+@RequestMapping("/api/movies")
+@RequiredArgsConstructor
+public class MovieClientController {
+
+    private final MovieService movieService;
+
+    @Operation(summary = "영화 목록 조회 (현재 상영작 및 개봉 예정작)",
+            description = "사용자에게 보여줄 현재 상영작 및 개봉 예정작 목록을 조회합니다. 정렬: 현재 상영작 우선, 그 다음 개봉일 최신순.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "영화 목록 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<List<MovieListItemDto>> getMovieListForUser() {
+        List<MovieListItemDto> movies = movieService.getMovieListForUser();
+        return ResponseEntity.ok(movies);
+    }
+
+    @Operation(summary = "영화 상세 정보 조회", description = "특정 영화의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "영화 상세 정보 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 영화를 찾을 수 없습니다.")
+    })
+    @GetMapping("/{movieId}")
+    public ResponseEntity<MovieResponseDto> getMovieDetailForUser(
+            @Parameter(description = "조회할 영화의 ID", required = true, example = "1")
+            @PathVariable Long movieId) {
+        MovieResponseDto movieDetail = movieService.getMovieDetail(movieId);
+        return ResponseEntity.ok(movieDetail);
+    }
+}

--- a/src/main/java/com/uos/picobox/client/controller/screening/ScreeningClientController.java
+++ b/src/main/java/com/uos/picobox/client/controller/screening/ScreeningClientController.java
@@ -1,0 +1,64 @@
+package com.uos.picobox.client.controller.screening;
+
+import com.uos.picobox.domain.screening.dto.ScreeningScheduleResponseDto;
+import com.uos.picobox.domain.screening.service.ScreeningService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "사용자 - 상영 스케줄 조회", description = "사용자 대상 상영 스케줄 조회 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ScreeningClientController {
+
+    private final ScreeningService screeningService;
+
+    @Operation(summary = "특정 날짜의 전체 상영 시간표 조회",
+            description = "주어진 날짜의 모든 상영 스케줄 목록을 조회합니다. 결과는 상영 시간 오름차순으로 정렬됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상영 시간표 조회 성공"),
+            @ApiResponse(responseCode = "204", description = "해당 날짜에 상영 정보 없음")
+    })
+    @GetMapping("/screenings")
+    public ResponseEntity<List<ScreeningScheduleResponseDto>> getScreeningsByDate(
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식)", required = true, example = "2025-06-04")
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        List<ScreeningScheduleResponseDto> schedules = screeningService.getScreeningSchedulesByDate(date);
+        if (schedules.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(schedules);
+    }
+
+    @Operation(summary = "특정 영화의 특정 날짜 상영 시간표 조회",
+            description = "주어진 영화의 주어진 날짜 상영 스케줄 목록을 조회합니다. 결과는 상영 시간 오름차순으로 정렬됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상영 시간표 조회 성공"),
+            @ApiResponse(responseCode = "204", description = "해당 조건에 맞는 상영 정보 없음"),
+            @ApiResponse(responseCode = "404", description = "요청한 영화를 찾을 수 없습니다.")
+    })
+    @GetMapping("/movies/{movieId}/screenings")
+    public ResponseEntity<List<ScreeningScheduleResponseDto>> getScreeningsByMovieAndDate(
+            @Parameter(description = "영화를 식별하기 위한 ID", required = true)
+            @PathVariable Long movieId,
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식)", required = true, example = "2025-06-04")
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        List<ScreeningScheduleResponseDto> schedules = screeningService.getScreeningSchedulesByMovieAndDate(movieId, date);
+        if (schedules.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(schedules);
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieListItemDto.java
+++ b/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieListItemDto.java
@@ -1,0 +1,59 @@
+package com.uos.picobox.domain.movie.dto.movie;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.uos.picobox.domain.movie.entity.Movie;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MovieListItemDto {
+
+    @Schema(description = "정렬 순서에 따른 순번", example = "1")
+    private int rank;
+
+    @Schema(description = "영화 ID", example = "1")
+    private Long movieId;
+
+    @Schema(description = "영화 제목", example = "서울의 봄")
+    private String title;
+
+    @Schema(description = "포스터 이미지 URL")
+    private String posterUrl;
+
+    @Schema(description = "개봉일 (yyyy-MM-dd)", example = "2023-11-22")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate releaseDate;
+
+    @Schema(description = "관람 등급명", example = "12세 이상 관람가")
+    private String movieRatingName;
+
+    @Schema(description = "상영 시간 (분 단위)", example = "141")
+    private Integer duration;
+
+    @Builder
+    public MovieListItemDto(int rank, Long movieId, String title, String posterUrl,
+                            LocalDate releaseDate, String movieRatingName, Integer duration) {
+        this.rank = rank;
+        this.movieId = movieId;
+        this.title = title;
+        this.posterUrl = posterUrl;
+        this.releaseDate = releaseDate;
+        this.movieRatingName = movieRatingName;
+        this.duration = duration;
+    }
+
+    public static MovieListItemDto fromEntity(Movie movie, int rank) {
+        return MovieListItemDto.builder()
+                .rank(rank)
+                .movieId(movie.getId())
+                .title(movie.getTitle())
+                .posterUrl(movie.getPosterUrl())
+                .releaseDate(movie.getReleaseDate())
+                .movieRatingName(movie.getMovieRating() != null ? movie.getMovieRating().getRatingName() : null)
+                .duration(movie.getDuration())
+                .build();
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieRequestDto.java
+++ b/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieRequestDto.java
@@ -33,6 +33,10 @@ public class MovieRequestDto {
     @Schema(description = "개봉일 (yyyy-MM-dd)", example = "2019-01-23", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate releaseDate;
 
+    @Schema(description = "상영 종료 예정일 (yyyy-MM-dd 형식, 선택 사항). 지정하지 않으면 미정으로 간주.",
+            example = "2025-08-31", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private LocalDate screeningEndDate;
+
     @Size(max = 30, message = "언어는 최대 30자까지 입력 가능합니다.")
     @Schema(description = "언어", example = "한국어", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String language;

--- a/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/movie/dto/movie/MovieResponseDto.java
@@ -31,6 +31,10 @@ public class MovieResponseDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate releaseDate;
 
+    @Schema(description = "상영 종료 예정일 (yyyy-MM-dd)", example = "2025-08-31", nullable = true)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate screeningEndDate;
+
     @Schema(description = "언어", example = "한국어")
     private String language;
 
@@ -52,11 +56,10 @@ public class MovieResponseDto {
     @Schema(description = "포스터 이미지 URL")
     private String posterUrl;
 
-    // MovieCast 정보를 담기 위한 내부 DTO
     @Getter
     public static class MovieCastMemberResponseDto {
         @Schema(description = "배우 정보")
-        private ActorSummaryDto actor; // (actorId, name)
+        private ActorSummaryDto actor;
 
         @Schema(description = "영화 내 역할", example = "고반장")
         private String role;
@@ -88,6 +91,7 @@ public class MovieResponseDto {
         this.description = movie.getDescription();
         this.duration = movie.getDuration();
         this.releaseDate = movie.getReleaseDate();
+        this.screeningEndDate = movie.getScreeningEndDate();
         this.language = movie.getLanguage();
         this.director = movie.getDirector();
         this.distributor = new DistributorResponseDto(movie.getDistributor());

--- a/src/main/java/com/uos/picobox/domain/movie/entity/Movie.java
+++ b/src/main/java/com/uos/picobox/domain/movie/entity/Movie.java
@@ -7,9 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -30,10 +28,13 @@ public class Movie {
     private String description;
 
     @Column(name = "DURATION", nullable = false)
-    private Integer duration; // 분 단위
+    private Integer duration;
 
     @Column(name = "RELEASE_DATE", nullable = false)
     private LocalDate releaseDate;
+
+    @Column(name = "SCREENING_END_DATE")
+    private LocalDate screeningEndDate;
 
     @Column(name = "LANGUAGE", length = 30)
     private String language;
@@ -57,15 +58,17 @@ public class Movie {
     private Set<MovieGenreMapping> genreMappings = new HashSet<>();
 
     @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<MovieCast> movieCasts = new ArrayList<>();
+    private Set<MovieCast> movieCasts = new HashSet<>();
 
     @Builder
     public Movie(String title, String description, Integer duration, LocalDate releaseDate,
-                 String language, String director, Distributor distributor, MovieRating movieRating, String posterUrl) {
+                 LocalDate screeningEndDate, String language, String director,
+                 Distributor distributor, MovieRating movieRating, String posterUrl) {
         this.title = title;
         this.description = description;
         this.duration = duration;
         this.releaseDate = releaseDate;
+        this.screeningEndDate = screeningEndDate;
         this.language = language;
         this.director = director;
         this.distributor = distributor;
@@ -74,11 +77,13 @@ public class Movie {
     }
 
     public void updateDetails(String title, String description, Integer duration, LocalDate releaseDate,
-                              String language, String director, Distributor distributor, MovieRating movieRating) {
+                              LocalDate screeningEndDate, String language, String director,
+                              Distributor distributor, MovieRating movieRating) {
         this.title = title;
         this.description = description;
         this.duration = duration;
         this.releaseDate = releaseDate;
+        this.screeningEndDate = screeningEndDate;
         this.language = language;
         this.director = director;
         this.distributor = distributor;

--- a/src/main/java/com/uos/picobox/domain/movie/repository/MovieRepository.java
+++ b/src/main/java/com/uos/picobox/domain/movie/repository/MovieRepository.java
@@ -3,6 +3,10 @@ package com.uos.picobox.domain.movie.repository;
 import com.uos.picobox.domain.movie.entity.Movie;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.List;
 
@@ -16,4 +20,37 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
     List<Movie> findAll();
 
     Optional<Movie> findByTitleAndReleaseDate(String title, java.time.LocalDate releaseDate);
+
+    /**
+     * 모든 영화 목록을 모든 상세 정보와 함께 조회합니다.
+     */
+    @Query("SELECT DISTINCT m FROM Movie m " +
+            "LEFT JOIN FETCH m.distributor " +
+            "LEFT JOIN FETCH m.movieRating " +
+            "LEFT JOIN FETCH m.genreMappings mgm JOIN FETCH mgm.movieGenre " +
+            "LEFT JOIN FETCH m.movieCasts mc JOIN FETCH mc.actor")
+    List<Movie> findAllWithDetails();
+
+    /**
+     * 활성(현재 상영 중 또는 상영 종료일 미정/미래) 및 개봉 예정 영화 목록을 조회합니다.
+     * 개봉일 최신순으로 정렬합니다.
+     */
+    @Query("SELECT DISTINCT m FROM Movie m " +
+            "LEFT JOIN FETCH m.movieRating mr " +
+            "WHERE (m.screeningEndDate IS NULL OR m.screeningEndDate >= :today) " +
+            "OR m.releaseDate > :today")
+    List<Movie> findActiveAndUpcomingMovies(@Param("today") LocalDate today);
+
+    /**
+     * 상세 조회용: 특정 영화의 모든 상세 정보를 조회합니다.
+     */
+    @Query("SELECT DISTINCT m FROM Movie m " + // 'DISTINCT' 추가
+            "LEFT JOIN FETCH m.distributor " +
+            "LEFT JOIN FETCH m.movieRating " +
+            "LEFT JOIN FETCH m.genreMappings mgm " +
+            "LEFT JOIN FETCH mgm.movieGenre " +
+            "LEFT JOIN FETCH m.movieCasts mc " +
+            "LEFT JOIN FETCH mc.actor " +
+            "WHERE m.id = :movieId")
+    Optional<Movie> findMovieDetailsById(@Param("movieId") Long movieId);
 }

--- a/src/main/java/com/uos/picobox/domain/movie/service/MovieService.java
+++ b/src/main/java/com/uos/picobox/domain/movie/service/MovieService.java
@@ -123,7 +123,11 @@ public class MovieService {
 
         if (posterImageFile != null && !posterImageFile.isEmpty()) {
             if (StringUtils.hasText(movie.getPosterUrl())) {
-                s3Service.delete(movie.getPosterUrl());
+                try {
+                    s3Service.delete(movie.getPosterUrl());
+                } catch (SdkException e) {
+                    log.error("MovieService: 포스터 삭제 실패. URL: " + movie.getPosterUrl(), e);
+                }
             }
             try {
                 String newPosterS3Url = s3Service.upload(posterImageFile, "movie-posters");

--- a/src/main/java/com/uos/picobox/domain/movie/service/MovieService.java
+++ b/src/main/java/com/uos/picobox/domain/movie/service/MovieService.java
@@ -1,22 +1,26 @@
 package com.uos.picobox.domain.movie.service;
 
+import com.uos.picobox.domain.movie.dto.movie.MovieListItemDto;
 import com.uos.picobox.domain.movie.dto.movie.MovieRequestDto;
 import com.uos.picobox.domain.movie.dto.movie.MovieResponseDto;
 import com.uos.picobox.domain.movie.entity.*;
 import com.uos.picobox.domain.movie.repository.*;
 import com.uos.picobox.global.service.S3Service;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,9 +37,12 @@ public class MovieService {
     private final ActorRepository actorRepository;
     private final S3Service s3Service;
 
+    // --- 관리자용 CRUD 메소드 ---
+
     @Transactional
     public MovieResponseDto registerMovie(MovieRequestDto requestDto, MultipartFile posterImageFile) {
         LocalDate releaseDate = requestDto.getReleaseDate();
+        LocalDate screeningEndDate = requestDto.getScreeningEndDate();
 
         movieRepository.findByTitleAndReleaseDate(requestDto.getTitle(), releaseDate)
                 .ifPresent(m -> {
@@ -53,7 +60,7 @@ public class MovieService {
                 posterS3Url = s3Service.upload(posterImageFile, "movie-posters");
             } catch (IOException | SdkException e) {
                 log.error("MovieService: 포스터 이미지 업로드 실패.", e);
-                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다.", e);
             }
         }
 
@@ -62,6 +69,7 @@ public class MovieService {
                 .description(requestDto.getDescription())
                 .duration(requestDto.getDuration())
                 .releaseDate(releaseDate)
+                .screeningEndDate(screeningEndDate)
                 .language(requestDto.getLanguage())
                 .director(requestDto.getDirector())
                 .distributor(distributor)
@@ -69,38 +77,22 @@ public class MovieService {
                 .posterUrl(posterS3Url)
                 .build();
 
-        // 장르 매핑 처리
-        if (!CollectionUtils.isEmpty(requestDto.getGenreIds())) {
+        if (requestDto.getGenreIds() != null) {
             requestDto.getGenreIds().forEach(genreId -> {
                 MovieGenre movieGenre = movieGenreRepository.findById(genreId)
                         .orElseThrow(() -> new EntityNotFoundException("장르를 찾을 수 없습니다: ID " + genreId));
                 movie.addGenreMapping(new MovieGenreMapping(movie, movieGenre));
             });
         }
-
-        // 출연진 매핑 처리
-        if (!CollectionUtils.isEmpty(requestDto.getMovieCasts())) {
+        if (requestDto.getMovieCasts() != null) {
             requestDto.getMovieCasts().forEach(castDto -> {
                 Actor actor = actorRepository.findById(castDto.getActorId())
                         .orElseThrow(() -> new EntityNotFoundException("배우를 찾을 수 없습니다: ID " + castDto.getActorId()));
                 movie.addMovieCast(new MovieCast(movie, actor, castDto.getRole()));
             });
         }
-
         Movie savedMovie = movieRepository.save(movie);
         return new MovieResponseDto(savedMovie);
-    }
-
-    public List<MovieResponseDto> findAllMovies() {
-        return movieRepository.findAll().stream()
-                .map(MovieResponseDto::new)
-                .collect(Collectors.toList());
-    }
-
-    public MovieResponseDto findMovieById(Long movieId) {
-        Movie movie = movieRepository.findById(movieId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
-        return new MovieResponseDto(movie);
     }
 
     @Transactional
@@ -109,8 +101,8 @@ public class MovieService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
 
         LocalDate releaseDate = requestDto.getReleaseDate();
+        LocalDate screeningEndDate = requestDto.getScreeningEndDate();
 
-        // 제목, 개봉일 변경 시 중복 체크
         if (!movie.getTitle().equals(requestDto.getTitle()) || !movie.getReleaseDate().equals(releaseDate)) {
             movieRepository.findByTitleAndReleaseDate(requestDto.getTitle(), releaseDate)
                     .filter(existingMovie -> !existingMovie.getId().equals(movieId))
@@ -118,64 +110,51 @@ public class MovieService {
                         throw new IllegalArgumentException("이미 동일한 제목과 개봉일의 다른 영화가 존재합니다.");
                     });
         }
-
         Distributor distributor = distributorRepository.findById(requestDto.getDistributorId())
                 .orElseThrow(() -> new EntityNotFoundException("배급사를 찾을 수 없습니다: ID " + requestDto.getDistributorId()));
         MovieRating movieRating = movieRatingRepository.findById(requestDto.getMovieRatingId())
                 .orElseThrow(() -> new EntityNotFoundException("영화 등급을 찾을 수 없습니다: ID " + requestDto.getMovieRatingId()));
 
         movie.updateDetails(
-                requestDto.getTitle(),
-                requestDto.getDescription(),
-                requestDto.getDuration(),
-                releaseDate,
-                requestDto.getLanguage(),
-                requestDto.getDirector(),
-                distributor,
-                movieRating
+                requestDto.getTitle(), requestDto.getDescription(), requestDto.getDuration(),
+                releaseDate, screeningEndDate, requestDto.getLanguage(), requestDto.getDirector(),
+                distributor, movieRating
         );
 
-        String currentPosterUrl = movie.getPosterUrl();
-        String finalPosterS3Url = currentPosterUrl;
-
         if (posterImageFile != null && !posterImageFile.isEmpty()) {
-            if (StringUtils.hasText(currentPosterUrl)) {
-                try {
-                    s3Service.delete(currentPosterUrl);
-                } catch (Exception e) {
-                    log.warn("기존 포스터 이미지 S3 삭제 중 오류 발생 (무시하고 진행): " + e.getMessage());
-                }
+            if (StringUtils.hasText(movie.getPosterUrl())) {
+                s3Service.delete(movie.getPosterUrl());
             }
             try {
-                finalPosterS3Url = s3Service.upload(posterImageFile, "movie-posters");
+                String newPosterS3Url = s3Service.upload(posterImageFile, "movie-posters");
+                movie.updatePosterUrl(newPosterS3Url);
             } catch (IOException | SdkException e) {
-                log.error("MovieService: 포스터 이미지 수정 업로드 실패.", e);
-                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+                log.error("MovieService: 포스터 수정 업로드 실패.", e);
+                throw new RuntimeException("포스터 업로드 오류: " + e.getMessage(), e);
             }
         }
-        movie.updatePosterUrl(finalPosterS3Url);
 
-        // 장르 매핑 업데이트
-        movie.clearGenreMappings();
-        if (!CollectionUtils.isEmpty(requestDto.getGenreIds())) {
-            requestDto.getGenreIds().forEach(genreId -> {
-                MovieGenre movieGenre = movieGenreRepository.findById(genreId)
-                        .orElseThrow(() -> new EntityNotFoundException("장르를 찾을 수 없습니다: ID " + genreId));
-                movie.addGenreMapping(new MovieGenreMapping(movie, movieGenre));
-            });
+        if (requestDto.getGenreIds() != null) {
+            movie.clearGenreMappings();
+            if (!requestDto.getGenreIds().isEmpty()) {
+                requestDto.getGenreIds().forEach(genreId -> {
+                    MovieGenre movieGenre = movieGenreRepository.findById(genreId)
+                            .orElseThrow(() -> new EntityNotFoundException("장르를 찾을 수 없습니다: ID " + genreId));
+                    movie.addGenreMapping(new MovieGenreMapping(movie, movieGenre));
+                });
+            }
         }
 
-        // 출연진 매핑 업데이트
-        movie.clearMovieCasts();
-        if (!CollectionUtils.isEmpty(requestDto.getMovieCasts())) {
-            requestDto.getMovieCasts().forEach(castDto -> {
-                Actor actor = actorRepository.findById(castDto.getActorId())
-                        .orElseThrow(() -> new EntityNotFoundException("배우를 찾을 수 없습니다: ID " + castDto.getActorId()));
-                movie.addMovieCast(new MovieCast(movie, actor, castDto.getRole()));
-            });
+        if (requestDto.getMovieCasts() != null) {
+            movie.clearMovieCasts();
+            if (!requestDto.getMovieCasts().isEmpty()) {
+                requestDto.getMovieCasts().forEach(castDto -> {
+                    Actor actor = actorRepository.findById(castDto.getActorId())
+                            .orElseThrow(() -> new EntityNotFoundException("배우를 찾을 수 없습니다: ID " + castDto.getActorId()));
+                    movie.addMovieCast(new MovieCast(movie, actor, castDto.getRole()));
+                });
+            }
         }
-
-        movieRepository.save(movie);
         return new MovieResponseDto(movie);
     }
 
@@ -183,28 +162,19 @@ public class MovieService {
     public MovieResponseDto uploadMoviePoster(Long movieId, MultipartFile posterImageFile) {
         Movie movie = movieRepository.findById(movieId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
-
         String newPosterS3Url = null;
-
         if (StringUtils.hasText(movie.getPosterUrl())) {
-            try {
-                s3Service.delete(movie.getPosterUrl());
-            } catch (Exception e) {
-                log.warn("포스터 변경/삭제 시 기존 S3 이미지 삭제 중 오류 발생 (무시하고 진행): " + e.getMessage());
-            }
+            s3Service.delete(movie.getPosterUrl());
         }
-
         if (posterImageFile != null && !posterImageFile.isEmpty()) {
             try {
                 newPosterS3Url = s3Service.upload(posterImageFile, "movie-posters");
             } catch (IOException | SdkException e) {
-                log.error("MovieService: 포스터 이미지 업로드 실패 (movieId: {}).", movieId, e);
-                throw new RuntimeException("포스터 이미지 업로드 중 오류가 발생했습니다: " + e.getMessage(), e);
+                log.error("MovieService: 포스터 업로드 실패 (movieId: {}).", movieId, e);
+                throw new RuntimeException("포스터 업로드 오류: " + e.getMessage(), e);
             }
         }
-
         movie.updatePosterUrl(newPosterS3Url);
-        movieRepository.save(movie);
         return new MovieResponseDto(movie);
     }
 
@@ -212,14 +182,82 @@ public class MovieService {
     public void removeMovie(Long movieId) {
         Movie movie = movieRepository.findById(movieId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
-
         if (StringUtils.hasText(movie.getPosterUrl())) {
-            try {
-                s3Service.delete(movie.getPosterUrl());
-            } catch (Exception e) {
-                log.warn("영화 삭제 중 S3 포스터 이미지 삭제 실패 (무시하고 진행): " + e.getMessage());
-            }
+            s3Service.delete(movie.getPosterUrl());
         }
         movieRepository.delete(movie);
+    }
+
+    public List<MovieResponseDto> findAllMoviesForAdmin() {
+        return movieRepository.findAllWithDetails().stream()
+                .map(MovieResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    public MovieResponseDto getMovieDetail(Long movieId) {
+        Movie movie = movieRepository.findMovieDetailsById(movieId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 영화를 찾을 수 없습니다: " + movieId));
+        return new MovieResponseDto(movie);
+    }
+
+    // --- 사용자용 API 메소드 ---
+    public List<MovieListItemDto> getMovieListForUser() {
+        LocalDate today = LocalDate.now();
+        List<Movie> candidateMovies = movieRepository.findActiveAndUpcomingMovies(today);
+
+        if (candidateMovies.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<MovieListItemDtoInternal> processedMovies = new ArrayList<>();
+
+        for (Movie movie : candidateMovies) {
+            String status;
+            LocalDate releaseDate = movie.getReleaseDate();
+            LocalDate screeningEndDate = movie.getScreeningEndDate();
+
+            if (releaseDate.isAfter(today)) {
+                status = "UPCOMING";
+            } else { // 개봉일 <= 오늘
+                if (screeningEndDate == null || !screeningEndDate.isBefore(today)) {
+                    // 상영 종료일이 없거나(미정), 오늘 이후이면 "현재 상영중"
+                    status = "NOW_PLAYING";
+                } else {
+                    // 상영 종료일이 오늘 이전이면 "상영 종료"
+                    status = "ENDED";
+                }
+            }
+
+            if ("NOW_PLAYING".equals(status) || "UPCOMING".equals(status)) {
+                processedMovies.add(new MovieListItemDtoInternal(movie, status));
+            }
+        }
+
+        processedMovies.sort(Comparator
+                .comparing(MovieListItemDtoInternal::getStatusSortOrder)
+                .thenComparing(m -> m.getMovie().getReleaseDate(), Comparator.reverseOrder())
+                .thenComparing(m -> m.getMovie().getId(), Comparator.reverseOrder())
+        );
+
+        List<MovieListItemDto> result = new ArrayList<>();
+        for (int i = 0; i < processedMovies.size(); i++) {
+            Movie movie = processedMovies.get(i).getMovie();
+            result.add(MovieListItemDto.fromEntity(movie, i + 1));
+        }
+        return result;
+    }
+
+    @Getter
+    private static class MovieListItemDtoInternal {
+        private final Movie movie;
+        private final String status;
+        private final int statusSortOrder;
+        public MovieListItemDtoInternal(Movie movie, String status) {
+            this.movie = movie;
+            this.status = status;
+            if ("NOW_PLAYING".equals(status)) {this.statusSortOrder = 0;}
+            else if ("UPCOMING".equals(status)) {this.statusSortOrder = 1;}
+            else {this.statusSortOrder = 2;}
+        }
     }
 }

--- a/src/main/java/com/uos/picobox/domain/screening/dto/ScreeningScheduleResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/screening/dto/ScreeningScheduleResponseDto.java
@@ -1,0 +1,62 @@
+package com.uos.picobox.domain.screening.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.uos.picobox.domain.screening.entity.Screening;
+import com.uos.picobox.domain.screening.entity.SeatStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ScreeningScheduleResponseDto {
+
+    @Schema(description = "상영 ID", example = "1")
+    private Long screeningId;
+
+    @Schema(description = "영화 제목", example = "범죄도시4")
+    private String movieTitle;
+
+    @Schema(description = "상영관 이름", example = "2관")
+    private String roomName;
+
+    @Schema(description = "상영 시작 시간 (HH:mm 형식)", example = "10:30")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalDateTime screeningStartTime;
+
+    @Schema(description = "상영 종료 시간 (HH:mm 형식)", example = "12:19")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalDateTime screeningEndTime;
+
+    @Schema(description = "예매 가능 좌석 수", example = "118")
+    private Long availableSeatsCount;
+
+    @Schema(description = "전체 좌석 수", example = "120")
+    private Integer totalSeatsCount;
+
+    public ScreeningScheduleResponseDto(Screening screening) {
+        this.screeningId = screening.getId();
+
+        if (screening.getMovie() != null) {
+            this.movieTitle = screening.getMovie().getTitle();
+            if (screening.getMovie().getDuration() != null) {
+                this.screeningEndTime = screening.getScreeningTime().plusMinutes(screening.getMovie().getDuration());
+            }
+        }
+
+        if (screening.getScreeningRoom() != null) {
+            this.roomName = screening.getScreeningRoom().getRoomName();
+            this.totalSeatsCount = screening.getScreeningRoom().getCapacity();
+        }
+
+        this.screeningStartTime = screening.getScreeningTime();
+
+        if (screening.getScreeningSeats() != null) {
+            this.availableSeatsCount = screening.getScreeningSeats().stream()
+                    .filter(seat -> seat.getSeatStatus() == SeatStatus.AVAILABLE)
+                    .count();
+        } else {
+            this.availableSeatsCount = 0L;
+        }
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/screening/repository/ScreeningRepository.java
+++ b/src/main/java/com/uos/picobox/domain/screening/repository/ScreeningRepository.java
@@ -44,4 +44,31 @@ public interface ScreeningRepository extends JpaRepository<Screening, Long> {
             "JOIN FETCH s.screeningRoom sr " +
             "ORDER BY s.screeningTime DESC")
     List<Screening> findAllWithMovieAndRoom();
+
+    /**
+     * 사용자용: 특정 날짜의 모든 상영 스케줄을 조회합니다. (시간 오름차순 정렬)
+     * @param date 조회할 날짜
+     * @return 해당 날짜의 모든 상영 스케줄 목록
+     */
+    @Query("SELECT DISTINCT s FROM Screening s " +
+            "JOIN FETCH s.movie m " +
+            "JOIN FETCH s.screeningRoom sr " +
+            "LEFT JOIN FETCH s.screeningSeats ss " +
+            "WHERE s.screeningDate = :date " +
+            "ORDER BY s.screeningTime ASC")
+    List<Screening> findByScreeningDateForUser(@Param("date") LocalDate date);
+
+    /**
+     * 사용자용: 특정 영화의 특정 날짜 상영 스케줄을 조회합니다. (시간 오름차순 정렬)
+     * @param movieId 영화 ID
+     * @param date 조회할 날짜
+     * @return 해당 영화, 해당 날짜의 상영 스케줄 목록
+     */
+    @Query("SELECT DISTINCT s FROM Screening s " +
+            "JOIN FETCH s.movie m " +
+            "JOIN FETCH s.screeningRoom sr " +
+            "LEFT JOIN FETCH s.screeningSeats ss " +
+            "WHERE m.id = :movieId AND s.screeningDate = :date " +
+            "ORDER BY s.screeningTime ASC")
+    List<Screening> findByMovieIdAndScreeningDateForUser(@Param("movieId") Long movieId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/uos/picobox/domain/screening/service/ScreeningService.java
+++ b/src/main/java/com/uos/picobox/domain/screening/service/ScreeningService.java
@@ -7,6 +7,7 @@ import com.uos.picobox.domain.room.entity.Seat;
 import com.uos.picobox.domain.room.repository.ScreeningRoomRepository;
 import com.uos.picobox.domain.screening.dto.ScreeningRequestDto;
 import com.uos.picobox.domain.screening.dto.ScreeningResponseDto;
+import com.uos.picobox.domain.screening.dto.ScreeningScheduleResponseDto;
 import com.uos.picobox.domain.screening.entity.Screening;
 import com.uos.picobox.domain.screening.entity.ScreeningSeat;
 import com.uos.picobox.domain.screening.entity.SeatStatus;
@@ -99,7 +100,7 @@ public class ScreeningService {
     private void validateNoOverlap(Long roomId, LocalDateTime newStartTime, LocalDateTime newEndTime, Long screeningIdToExclude, LocalDate targetDate) {
         List<Screening> existingScreenings = screeningRepository.findByScreeningRoomIdAndScreeningDateOrderByScreeningTimeAsc(roomId, targetDate);
         for (Screening existing : existingScreenings) {
-            if (screeningIdToExclude != null && existing.getId().equals(screeningIdToExclude)) {
+            if (existing.getId().equals(screeningIdToExclude)) {
                 continue;
             }
             if (existing.getMovie() == null || existing.getMovie().getDuration() == null || existing.getMovie().getDuration() <= 0) {
@@ -207,6 +208,33 @@ public class ScreeningService {
         }
         screeningRepository.delete(screening);
         log.info("상영 스케줄이 삭제되었습니다: ID {}", screeningId);
+    }
+
+    // --- 사용자용 API 메소드 ---
+
+    /**
+     * 특정 날짜의 모든 상영 스케줄 목록을 조회합니다.
+     * @param date 조회할 날짜
+     * @return 해당 날짜의 상영 스케줄 목록
+     */
+    public List<ScreeningScheduleResponseDto> getScreeningSchedulesByDate(LocalDate date) {
+        List<Screening> screenings = screeningRepository.findByScreeningDateForUser(date);
+        return screenings.stream()
+                .map(ScreeningScheduleResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 영화의 특정 날짜 상영 스케줄 목록을 조회합니다.
+     * @param movieId 영화 ID
+     * @param date 조회할 날짜
+     * @return 해당 영화, 해당 날짜의 상영 스케줄 목록
+     */
+    public List<ScreeningScheduleResponseDto> getScreeningSchedulesByMovieAndDate(Long movieId, LocalDate date) {
+        List<Screening> screenings = screeningRepository.findByMovieIdAndScreeningDateForUser(movieId, date);
+        return screenings.stream()
+                .map(ScreeningScheduleResponseDto::new)
+                .collect(Collectors.toList());
     }
 }
 


### PR DESCRIPTION
1.  **영화 목록 조회 API (`GET /api/movies`):**
    * 사용자가 현재 상영 중인 영화와 개봉 예정인 영화 목록을 볼 수 있습니다.
2.  **영화 상세 정보 조회 API (`GET /api/movies/{movieId}`):**
    * 사용자가 특정 영화를 선택했을 때, 포스터, 줄거리, 출연진, 장르 등 모든 상세 정보를 제공합니다.
3.  **상영 스케줄 조회 API (`GET /api/screenings`, `GET /api/movies/{movieId}/screenings`):**
    * 특정 날짜의 전체 상영 시간표 또는 특정 영화의 시간표를 조회할 수 있습니다.

## 주요 변경 사항 및 결정 사항

### 1. 영화 목록 및 상태 판별 로직
* **`screeningEndDate` 필드 추가:** 영화의 상영 상태를 동적으로 계산하는 구현이 복잡해서 상영 종료 일자 필드 추가
* **상태 판별 로직:**
    * **개봉 예정:** `releaseDate > today`
    * **현재 상영중:** `releaseDate <= today` AND (`screeningEndDate == null or today <= screeningEndDate`)
* **정렬 기준:** 현재 상영중 영화를 우선 표시 후 개봉일 최신순으로 정렬 -> 예매 기능 구현 시 예매율 순서 정렬로 하면 좋을 거 같음.

### 2. 상영 스케줄 조회 기능 구현
* **API 엔드포인트:** 날짜별 전체 조회(`GET /api/screenings?date=...`) 및 영화별/날짜별 조회(`GET /api/movies/{movieId}/screenings?date=...`) 기능을 모두 제공.
* **응답 DTO (`ScreeningScheduleResponseDto`):** 영화 제목, 상영관 이름, 시작 시간, 종료 시간, 총 좌석 수/예매 가능 좌석 수

resolves: #32 