### PR TITLE
feat: 예매 API 구현

### DIFF
--- a/src/main/java/com/uos/picobox/BePicoboxApplication.java
+++ b/src/main/java/com/uos/picobox/BePicoboxApplication.java
@@ -2,7 +2,9 @@ package com.uos.picobox;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BePicoboxApplication {
 

--- a/src/main/java/com/uos/picobox/client/controller/reservation/ReservationController.java
+++ b/src/main/java/com/uos/picobox/client/controller/reservation/ReservationController.java
@@ -1,0 +1,107 @@
+package com.uos.picobox.client.controller.reservation;
+
+import com.uos.picobox.domain.reservation.dto.PaymentRequestDto;
+import com.uos.picobox.domain.reservation.dto.ReservationRequestDto;
+import com.uos.picobox.domain.reservation.dto.ReservationResponseDto;
+import com.uos.picobox.domain.reservation.dto.SeatRequestDto;
+import com.uos.picobox.domain.reservation.service.ReservationService;
+import com.uos.picobox.global.utils.SessionUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "사용자 - 티켓 예매", description = "좌석 선택, 예매, 결제 완료 처리 API")
+@RestController
+@RequestMapping("/api/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+    private final SessionUtil sessionUtil;
+
+    @Operation(summary = "좌석 선점 (HOLD)", description = "사용자가 선택한 좌석을 10분간 선점합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "좌석 선점 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상영 또는 좌석"),
+            @ApiResponse(responseCode = "409", description = "이미 선택된 좌석")
+    })
+    @PostMapping("/hold")
+    public ResponseEntity<Void> holdSeats(
+            @Valid @RequestBody SeatRequestDto dto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        reservationService.holdSeats(dto, customerId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "좌석 선점 해제 (Release)", description = "사용자가 명시적으로 취소하거나 이탈 시 호출하여 선점한 좌석을 해제합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "좌석 선점 해제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 상영 또는 좌석")
+    })
+    @PostMapping("/release")
+    public ResponseEntity<Void> releaseSeats(
+            @Valid @RequestBody SeatRequestDto dto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        reservationService.releaseSeats(dto, customerId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "결제 전 예매 생성", description = "선점한 좌석과 사용할 포인트를 기반으로 결제 대기(PENDING) 상태의 예매를 생성합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "결제 대기 예매 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "포인트 부족 또는 잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "409", description = "선점되지 않은 좌석 포함")
+    })
+    @PostMapping("/create")
+    public ResponseEntity<ReservationResponseDto> createPendingReservation(
+            @Valid @RequestBody ReservationRequestDto dto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        ReservationResponseDto responseDto = reservationService.createPendingReservation(dto, customerId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @Operation(summary = "결제 완료 처리", description = "결제 성공 후 호출되어 예매 상태를 최종 완료(COMPLETED) 처리합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "결제 완료 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 예약"),
+            @ApiResponse(responseCode = "409", description = "이미 처리된 예약")
+    })
+    @PostMapping("/complete")
+    public ResponseEntity<Void> completeReservation(
+            @Valid @RequestBody PaymentRequestDto dto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        reservationService.completeReservation(dto, customerId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "내 예매 내역 조회", description = "현재 로그인한 사용자의 예매 내역을 조회합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "예매 내역 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/my-reservations")
+    public ResponseEntity<List<ReservationResponseDto>> getMyReservations(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        List<ReservationResponseDto> reservations = reservationService.getReservationsByCustomerId(customerId);
+        return ResponseEntity.ok(reservations);
+    }
+}

--- a/src/main/java/com/uos/picobox/client/controller/screening/ScreeningClientController.java
+++ b/src/main/java/com/uos/picobox/client/controller/screening/ScreeningClientController.java
@@ -1,6 +1,7 @@
 package com.uos.picobox.client.controller.screening;
 
 import com.uos.picobox.domain.screening.dto.ScreeningScheduleResponseDto;
+import com.uos.picobox.domain.screening.dto.ScreeningSeatsResponseDto;
 import com.uos.picobox.domain.screening.service.ScreeningService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -60,5 +61,19 @@ public class ScreeningClientController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(schedules);
+    }
+
+    @Operation(summary = "특정 상영의 좌석 상태 전체 조회",
+            description = "주어진 상영 ID에 해당하는 상영관의 모든 좌석 상태(예매 가능, 판매 완료 등) 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "좌석 상태 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 상영 정보를 찾을 수 없습니다.")
+    })
+    @GetMapping("/screenings/{screeningId}/seats")
+    public ResponseEntity<ScreeningSeatsResponseDto> getScreeningSeats(
+            @Parameter(description = "좌석을 조회할 상영의 ID", required = true, example = "1")
+            @PathVariable Long screeningId) {
+        ScreeningSeatsResponseDto seatsResponse = screeningService.getSeatsForScreening(screeningId);
+        return ResponseEntity.ok(seatsResponse);
     }
 }

--- a/src/main/java/com/uos/picobox/domain/point/entity/PointChangeType.java
+++ b/src/main/java/com/uos/picobox/domain/point/entity/PointChangeType.java
@@ -1,0 +1,9 @@
+package com.uos.picobox.domain.point.entity;
+
+public enum PointChangeType {
+    EARNED,
+    USED,
+    EXPIRED,
+    ADJUSTED,
+    REFUNDED
+}

--- a/src/main/java/com/uos/picobox/domain/point/entity/PointHistory.java
+++ b/src/main/java/com/uos/picobox/domain/point/entity/PointHistory.java
@@ -1,0 +1,48 @@
+package com.uos.picobox.domain.point.entity;
+
+import com.uos.picobox.user.entity.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "POINT_HISTORY")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "POINT_HISTORY_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CUSTOMER_ID", nullable = false)
+    private Customer customer;
+
+    @Column(name = "CHANGE_TYPE", nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    private PointChangeType changeType;
+
+    @Column(name = "AMOUNT", nullable = false)
+    private Integer amount;
+
+    @Column(name = "RELATED_RESERVATION_ID")
+    private Long relatedReservationId;
+
+    @Column(name = "CREATED_AT", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PointHistory(Customer customer, PointChangeType changeType, Integer amount, Long relatedReservationId) {
+        this.customer = customer;
+        this.changeType = changeType;
+        this.amount = amount;
+        this.relatedReservationId = relatedReservationId;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/point/repository/PointHistoryRepository.java
+++ b/src/main/java/com/uos/picobox/domain/point/repository/PointHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.uos.picobox.domain.point.repository;
+
+import com.uos.picobox.domain.point.entity.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/dto/PaymentRequestDto.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/dto/PaymentRequestDto.java
@@ -1,0 +1,34 @@
+package com.uos.picobox.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PaymentRequestDto {
+    @NotNull(message = "예약 ID는 필수입니다.")
+    @Schema(description = "결제를 완료할 예약 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long reservationId;
+
+    @NotBlank(message = "주문 ID는 필수입니다.")
+    @Schema(description = "결제 시스템에서 생성된 주문 ID", example = "ORDER_20241221_001", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String orderId;
+
+    @NotBlank(message = "결제 키는 필수입니다.")
+    @Schema(description = "결제 시스템에서 생성된 결제 키", example = "PAY_KEY_12345", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String paymentKey;
+
+    @NotBlank(message = "결제 수단 정보는 필수입니다.")
+    @Schema(description = "결제 수단", 
+            example = "CARD", requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"CARD", "VIRTUAL_ACCOUNT", "EASY_PAY", "GAME_GIFT", "TRANSFER", "BOOK_GIFT", "CULTURE_GIFT", "MOBILE"})
+    private String paymentMethod;
+
+    @Schema(description = "사용된 포인트 금액", example = "1000")
+    private Integer usedPointAmount = 0;
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/dto/ReservationRequestDto.java
@@ -1,0 +1,43 @@
+package com.uos.picobox.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReservationRequestDto {
+
+    @NotNull(message = "상영 ID는 필수입니다.")
+    @Schema(description = "예매할 상영 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long screeningId;
+
+    @NotEmpty(message = "티켓 정보는 최소 하나 이상 있어야 합니다.")
+    @Schema(description = "예매할 티켓 정보 목록")
+    private List<TicketInfo> tickets;
+
+    @NotNull(message = "사용할 포인트는 필수입니다. (사용 안 할 시 0)")
+    @Min(value = 0, message = "사용 포인트는 0 이상이어야 합니다.")
+    @Schema(description = "사용할 포인트 금액", example = "1000", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Integer usedPoints;
+
+    // 예매할 티켓 상세 정보
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class TicketInfo {
+        @NotNull
+        @Schema(description = "좌석 ID", example = "101", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long seatId;
+
+        @NotNull
+        @Schema(description = "티켓 종류 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long ticketTypeId;
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/dto/ReservationResponseDto.java
@@ -1,0 +1,50 @@
+package com.uos.picobox.domain.reservation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.uos.picobox.domain.reservation.entity.Reservation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ReservationResponseDto {
+
+    @Schema(description = "예약 ID", example = "1")
+    private final Long reservationId;
+
+    @Schema(description = "결제 상태", example = "PENDING")
+    private final String paymentStatus;
+
+    @Schema(description = "총 티켓 금액 (할인 전)", example = "30000")
+    private final Integer totalAmount;
+
+    @Schema(description = "사용 포인트", example = "1000")
+    private final Integer usedPoints;
+
+    @Schema(description = "최종 결제 필요 금액", example = "29000")
+    private final Integer finalAmount;
+
+    @Schema(description = "예약(결제 대기) 생성 시각")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+
+    @Schema(description = "영화 제목")
+    private final String movieTitle; // 필요에 따라 추가
+
+    @Schema(description = "선택한 좌석 목록")
+    private final List<String> seatNumbers; // 필요에 따라 추가
+
+    public ReservationResponseDto(Reservation reservation, int usedPoints, int finalAmount, String movieTitle, List<String> seatNumbers) {
+        this.reservationId = reservation.getId();
+        this.paymentStatus = reservation.getPaymentStatus().name();
+        this.totalAmount = reservation.getTotalAmount();
+        this.usedPoints = usedPoints;
+        this.finalAmount = finalAmount;
+        this.createdAt = reservation.getReservationDate();
+        this.movieTitle = movieTitle;
+        this.seatNumbers = seatNumbers;
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/dto/SeatRequestDto.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/dto/SeatRequestDto.java
@@ -1,0 +1,24 @@
+package com.uos.picobox.domain.reservation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SeatRequestDto {
+
+    @NotNull(message = "상영 ID는 필수입니다.")
+    @Schema(description = "좌석을 선택할 상영 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long screeningId;
+
+    @NotEmpty(message = "좌석 ID 목록은 비어있을 수 없습니다.")
+    @Schema(description = "선택(또는 해제)할 좌석 ID 목록", example = "[101, 102]", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<Long> seatIds;
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/entity/Payment.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/entity/Payment.java
@@ -1,0 +1,91 @@
+package com.uos.picobox.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "PAYMENT")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PAYMENT_ID")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "RESERVATION_ID", nullable = false)
+    private Reservation reservation;
+
+    @Column(name = "ORDER_ID", nullable = false, unique = true, length = 100)
+    private String orderId;
+
+    @Column(name = "PAYMENT_KEY", nullable = false, unique = true, length = 100)
+    private String paymentKey;
+
+    @Column(name = "PAYMENT_METHOD", nullable = false, length = 30)
+    private String paymentMethod;
+
+    @Column(name = "PAYMENT_STATUS", nullable = false, length = 30)
+    private String paymentStatus;
+
+    @Column(name = "CURRENCY", nullable = false, length = 10)
+    private String currency = "KRW";
+
+    @Column(name = "PAYMENT_DISCOUNT_ID")
+    private Long paymentDiscountId;
+
+    @Column(name = "USED_POINT_AMOUNT", nullable = false)
+    private Integer usedPointAmount = 0;
+
+    @Column(name = "AMOUNT", nullable = false)
+    private Integer amount;
+
+    @Column(name = "FINAL_AMOUNT", nullable = false)
+    private Integer finalAmount;
+
+    @Column(name = "APPROVED_AT")
+    private LocalDateTime approvedAt;
+
+    @CreationTimestamp
+    @Column(name = "REQUESTED_AT", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Builder
+    public Payment(Reservation reservation, String orderId, String paymentKey, 
+                   String paymentMethod, String paymentStatus, String currency,
+                   Long paymentDiscountId, Integer usedPointAmount, Integer amount, 
+                   Integer finalAmount, LocalDateTime approvedAt) {
+        this.reservation = reservation;
+        this.orderId = orderId;
+        this.paymentKey = paymentKey;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = paymentStatus;
+        this.currency = currency != null ? currency : "KRW";
+        this.paymentDiscountId = paymentDiscountId;
+        this.usedPointAmount = usedPointAmount != null ? usedPointAmount : 0;
+        this.amount = amount;
+        this.finalAmount = finalAmount;
+        this.approvedAt = approvedAt;
+    }
+
+    public void setReservation(Reservation reservation) {
+        this.reservation = reservation;
+    }
+
+    public void updateStatus(String paymentStatus) {
+        this.paymentStatus = paymentStatus;
+    }
+
+    public void approve() {
+        this.paymentStatus = "DONE";
+        this.approvedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/entity/PaymentMethod.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/entity/PaymentMethod.java
@@ -1,0 +1,12 @@
+package com.uos.picobox.domain.reservation.entity;
+
+public enum PaymentMethod {
+    CARD,           // 카드
+    VIRTUAL_ACCOUNT,// 가상계좌
+    EASY_PAY,       // 간편결제
+    GAME_GIFT,      // 게임문화상품권
+    TRANSFER,       // 계좌이체
+    BOOK_GIFT,      // 도서문화상품권
+    CULTURE_GIFT,   // 문화상품권
+    MOBILE          // 휴대폰
+} 

--- a/src/main/java/com/uos/picobox/domain/reservation/entity/PaymentStatus.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/entity/PaymentStatus.java
@@ -1,0 +1,31 @@
+package com.uos.picobox.domain.reservation.entity;
+
+public enum PaymentStatus {
+    // RESERVATION 테이블용
+    PENDING,
+    COMPLETED,
+    FAILED,
+    CANCELED,
+    
+    // PAYMENT 테이블용
+    ABORTED,
+    DONE,
+    EXPIRED,
+    IN_PROGRESS,
+    PARTIAL_CANCELED,
+    READY,
+    WAITING_FOR_DEPOSIT;
+
+    // 상태 확인 메서드들
+    public boolean isCompleted() {
+        return this == DONE;
+    }
+    
+    public boolean isPending() {
+        return this == IN_PROGRESS || this == READY || this == WAITING_FOR_DEPOSIT;
+    }
+    
+    public boolean isFailed() {
+        return this == ABORTED || this == EXPIRED || this == CANCELED || this == FAILED;
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/entity/Reservation.java
@@ -1,0 +1,79 @@
+package com.uos.picobox.domain.reservation.entity;
+
+import com.uos.picobox.user.entity.Customer;
+import com.uos.picobox.user.entity.Guest;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "RESERVATION")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "RESERVATION_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CUSTOMER_ID")
+    private Customer customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "GUEST_ID")
+    private Guest guest;
+
+    @Column(name = "SCREENING_ID", nullable = false)
+    private Long screeningId;
+
+    @Column(name = "RESERVATION_DATE", nullable = false)
+    private LocalDateTime reservationDate;
+
+    @Column(name = "TOTAL_AMOUNT", nullable = false)
+    private Integer totalAmount;
+
+    @Column(name = "PAYMENT_STATUS", nullable = false, length = 15)
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;
+
+    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Ticket> tickets = new ArrayList<>();
+
+    @OneToOne(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Payment payment;
+
+    @Builder
+    public Reservation(Customer customer, Guest guest, Long screeningId, Integer totalAmount, PaymentStatus paymentStatus) {
+        this.customer = customer;
+        this.guest = guest;
+        this.screeningId = screeningId;
+        this.totalAmount = totalAmount;
+        this.paymentStatus = paymentStatus;
+        this.reservationDate = LocalDateTime.now();
+    }
+
+    public void setPayment(Payment payment) {
+        this.payment = payment;
+        if (payment != null && payment.getReservation() != this) {
+            payment.setReservation(this);
+        }
+    }
+
+    public void addTicket(Ticket ticket) {
+        this.tickets.add(ticket);
+        if (ticket.getReservation() != this) {
+            ticket.setReservation(this);
+        }
+    }
+
+    public void updatePaymentStatus(PaymentStatus paymentStatus) {
+        this.paymentStatus = paymentStatus;
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/entity/Ticket.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/entity/Ticket.java
@@ -1,0 +1,57 @@
+package com.uos.picobox.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "TICKET")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "TICKET_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "RESERVATION_ID", nullable = false)
+    private Reservation reservation;
+
+    @Column(name = "SCREENING_ID", nullable = false)
+    private Long screeningId;
+
+    @Column(name = "SEAT_ID", nullable = false)
+    private Long seatId;
+
+    @Column(name = "TICKET_TYPE_ID", nullable = false)
+    private Long ticketTypeId;
+
+    @Column(name = "PRICE", nullable = false)
+    private Integer price;
+
+    @Column(name = "TICKET_STATUS", nullable = false, length = 15)
+    @Enumerated(EnumType.STRING)
+    private TicketStatus ticketStatus;
+
+    @Builder
+    public Ticket(Reservation reservation, Long screeningId, Long seatId, Long ticketTypeId, Integer price, TicketStatus ticketStatus) {
+        this.reservation = reservation;
+        this.screeningId = screeningId;
+        this.seatId = seatId;
+        this.ticketTypeId = ticketTypeId;
+        this.price = price;
+        this.ticketStatus = ticketStatus;
+    }
+
+    public void setReservation(Reservation reservation) {
+        this.reservation = reservation;
+    }
+
+    public void updateStatus(TicketStatus ticketStatus) {
+        this.ticketStatus = ticketStatus;
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/entity/TicketStatus.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/entity/TicketStatus.java
@@ -1,0 +1,8 @@
+package com.uos.picobox.domain.reservation.entity;
+
+public enum TicketStatus {
+    ISSUED,
+    USED,
+    CANCELED,
+    REFUNDED
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/repository/PaymentRepository.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.uos.picobox.domain.reservation.repository;
+
+import com.uos.picobox.domain.reservation.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.uos.picobox.domain.reservation.repository;
+
+import com.uos.picobox.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findByCustomerIdOrderByReservationDateDesc(Long customerId);
+    boolean existsByScreeningId(Long screeningId);
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/repository/TicketRepository.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/repository/TicketRepository.java
@@ -1,0 +1,7 @@
+package com.uos.picobox.domain.reservation.repository;
+
+import com.uos.picobox.domain.reservation.entity.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/scheduler/ReservationScheduler.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/scheduler/ReservationScheduler.java
@@ -1,0 +1,29 @@
+package com.uos.picobox.domain.reservation.scheduler;
+
+import com.uos.picobox.domain.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class ReservationScheduler {
+
+    private final ReservationService reservationService;
+
+    // 1분마다 실행 (fixedDelay = 60000ms)
+    @Scheduled(fixedDelay = 60000)
+    public void cleanupExpiredSeatHolds() {
+        log.info("선점 만료 좌석 정리 스케줄러 시작...");
+        try {
+            int releasedCount = reservationService.releaseExpiredHeldSeats();
+            log.info("만료된 좌석 {}개를 해제했습니다.", releasedCount);
+        } catch (Exception e) {
+            log.error("선점 만료 좌석 정리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/service/ReservationService.java
@@ -1,0 +1,305 @@
+package com.uos.picobox.domain.reservation.service;
+
+import com.uos.picobox.domain.point.entity.PointChangeType;
+import com.uos.picobox.domain.point.entity.PointHistory;
+import com.uos.picobox.domain.point.repository.PointHistoryRepository;
+import com.uos.picobox.domain.price.entity.RoomTicketTypePrice;
+import com.uos.picobox.domain.price.repository.RoomTicketTypePriceRepository;
+import com.uos.picobox.domain.reservation.dto.PaymentRequestDto;
+import com.uos.picobox.domain.reservation.dto.ReservationRequestDto;
+import com.uos.picobox.domain.reservation.dto.ReservationResponseDto;
+import com.uos.picobox.domain.reservation.dto.SeatRequestDto;
+import com.uos.picobox.domain.reservation.entity.*;
+import com.uos.picobox.domain.reservation.repository.PaymentRepository;
+import com.uos.picobox.domain.reservation.repository.ReservationRepository;
+import com.uos.picobox.domain.screening.entity.Screening;
+import com.uos.picobox.domain.screening.entity.ScreeningSeat;
+import com.uos.picobox.domain.screening.entity.SeatStatus;
+import com.uos.picobox.domain.screening.repository.ScreeningRepository;
+import com.uos.picobox.domain.screening.repository.ScreeningSeatRepository;
+import com.uos.picobox.user.entity.Customer;
+import com.uos.picobox.user.repository.CustomerRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final ScreeningSeatRepository screeningSeatRepository;
+    private final CustomerRepository customerRepository;
+    private final RoomTicketTypePriceRepository roomTicketTypePriceRepository;
+    private final ScreeningRepository screeningRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+    private final PaymentRepository paymentRepository;
+
+    private static final int SEAT_HOLD_MINUTES = 10;
+
+    /**
+     * 사용자가 선택한 좌석들을 일정 시간 동안 선점합니다.
+     * 선점된 좌석은 다른 사용자가 선택할 수 없으며, 지정된 시간(10분) 후 자동으로 해제됩니다.
+     * 
+     * @param dto 선점할 좌석 정보 (상영 ID, 좌석 ID 목록)
+     * @param customerId 좌석을 선점하는 고객 ID
+     * @throws IllegalStateException 이미 선점되었거나 판매된 좌석인 경우
+     * @throws EntityNotFoundException 존재하지 않는 좌석인 경우
+     */
+    @Transactional
+    public void holdSeats(SeatRequestDto dto, Long customerId) {
+        log.info("좌석 선점 요청: screeningId={}, seatIds={}, customerId={}", dto.getScreeningId(), dto.getSeatIds(), customerId);
+        for (Long seatId : dto.getSeatIds()) {
+            ScreeningSeat screeningSeat = screeningSeatRepository.findByIdWithPessimisticLock(dto.getScreeningId(), seatId)
+                    .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 좌석입니다. screeningId=" + dto.getScreeningId() + ", seatId=" + seatId));
+
+            if (screeningSeat.getSeatStatus() != SeatStatus.AVAILABLE) {
+                throw new IllegalStateException("이미 선택되었거나 예매가 불가능한 좌석입니다: seatId=" + seatId);
+            }
+
+            // 좌석 선점 및 선점한 고객 ID 기록
+            screeningSeat.setSeatStatus(SeatStatus.HOLD);
+            screeningSeat.setHoldExpiresAt(LocalDateTime.now().plusMinutes(SEAT_HOLD_MINUTES));
+            screeningSeat.setHoldCustomerId(customerId);
+            log.debug("좌석 선점 완료: screeningId={}, seatId={}, customerId={}", dto.getScreeningId(), seatId, customerId);
+        }
+    }
+
+    /**
+     * 사용자가 선점한 좌석들을 해제합니다.
+     * 선점한 본인만 해제할 수 있으며, 해제된 좌석은 다시 예매 가능 상태가 됩니다.
+     * 
+     * @param dto 해제할 좌석 정보 (상영 ID, 좌석 ID 목록)
+     * @param customerId 좌석을 해제하려는 고객 ID
+     * @throws IllegalStateException 다른 고객이 선점한 좌석을 해제하려는 경우
+     * @throws EntityNotFoundException 존재하지 않는 좌석인 경우
+     */
+    @Transactional
+    public void releaseSeats(SeatRequestDto dto, Long customerId) {
+        log.info("좌석 선점 해제 요청: screeningId={}, seatIds={}, customerId={}", dto.getScreeningId(), dto.getSeatIds(), customerId);
+        for (Long seatId : dto.getSeatIds()) {
+            ScreeningSeat screeningSeat = screeningSeatRepository.findById(new ScreeningSeat.ScreeningSeatId(dto.getScreeningId(), seatId))
+                    .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 좌석입니다. screeningId=" + dto.getScreeningId() + ", seatId=" + seatId));
+
+            if (screeningSeat.getSeatStatus() == SeatStatus.HOLD) {
+                // 선점한 고객이 맞는지 확인
+                if (screeningSeat.getHoldCustomerId() != null && !screeningSeat.getHoldCustomerId().equals(customerId)) {
+                    throw new IllegalStateException("다른 고객이 선점한 좌석은 해제할 수 없습니다: seatId=" + seatId);
+                }
+                
+                screeningSeat.setSeatStatus(SeatStatus.AVAILABLE);
+                screeningSeat.setHoldExpiresAt(null);
+                screeningSeat.setHoldCustomerId(null);
+                log.debug("좌석 선점 해제 완료: screeningId={}, seatId={}, customerId={}", dto.getScreeningId(), seatId, customerId);
+            }
+        }
+    }
+
+    /**
+     * 결제 대기 상태의 예매를 생성합니다.
+     * 선점된 좌석들을 바탕으로 예매를 생성하고, 사용된 포인트만큼 고객의 포인트를 차감합니다.
+     * 실제 결제는 별도의 completeReservation 메소드를 통해 완료됩니다.
+     * 
+     * @param dto 예매 정보 (상영 ID, 티켓 정보, 사용 포인트)
+     * @param customerId 예매하는 고객 ID
+     * @return 생성된 예매 정보
+     * @throws IllegalStateException 선점되지 않은 좌석을 예매하려는 경우
+     * @throws EntityNotFoundException 고객, 상영, 가격 정보를 찾을 수 없는 경우
+     */
+    @Transactional
+    public ReservationResponseDto createPendingReservation(ReservationRequestDto dto, Long customerId) {
+        Customer customer = customerRepository.findById(customerId)
+                .orElseThrow(() -> new EntityNotFoundException("고객 정보를 찾을 수 없습니다: " + customerId));
+
+        Screening screening = screeningRepository.findByIdWithDetails(dto.getScreeningId())
+                .orElseThrow(() -> new EntityNotFoundException("상영 정보를 찾을 수 없습니다: " + dto.getScreeningId()));
+
+        int totalAmount = 0;
+        for (ReservationRequestDto.TicketInfo ticketInfo : dto.getTickets()) {
+            RoomTicketTypePrice priceInfo = roomTicketTypePriceRepository.findById(
+                    new RoomTicketTypePrice.RoomTicketTypePriceId(screening.getScreeningRoom().getId(), ticketInfo.getTicketTypeId())
+            ).orElseThrow(() -> new EntityNotFoundException("해당 좌석 종류의 가격 정보를 찾을 수 없습니다."));
+            totalAmount += priceInfo.getPrice();
+        }
+
+        customer.usePoints(dto.getUsedPoints());
+        int finalAmount = totalAmount - dto.getUsedPoints();
+
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .screeningId(dto.getScreeningId())
+                .totalAmount(totalAmount)
+                .paymentStatus(PaymentStatus.PENDING)
+                .build();
+
+        List<String> seatNumbers = dto.getTickets().stream()
+                .map(ticketInfo -> {
+                    ScreeningSeat screeningSeat = screeningSeatRepository.findById(new ScreeningSeat.ScreeningSeatId(dto.getScreeningId(), ticketInfo.getSeatId()))
+                            .orElseThrow(() -> new EntityNotFoundException("좌석 정보를 찾을 수 없습니다: " + ticketInfo.getSeatId()));
+                    if(screeningSeat.getSeatStatus() != SeatStatus.HOLD) {
+                        throw new IllegalStateException("선점되지 않은 좌석을 예매할 수 없습니다: " + ticketInfo.getSeatId());
+                    }
+                    RoomTicketTypePrice priceInfo = roomTicketTypePriceRepository.findById(
+                            new RoomTicketTypePrice.RoomTicketTypePriceId(screening.getScreeningRoom().getId(), ticketInfo.getTicketTypeId())
+                    ).orElseThrow(() -> new EntityNotFoundException("가격 정보를 찾을 수 없습니다."));
+
+                    Ticket ticket = Ticket.builder()
+                            .reservation(reservation)
+                            .screeningId(dto.getScreeningId())
+                            .seatId(ticketInfo.getSeatId())
+                            .ticketTypeId(ticketInfo.getTicketTypeId())
+                            .price(priceInfo.getPrice())
+                            .ticketStatus(TicketStatus.ISSUED)
+                            .build();
+                    reservation.addTicket(ticket);
+                    return screeningSeat.getSeat().getSeatNumber();
+                })
+                .collect(Collectors.toList());
+
+        if (dto.getUsedPoints() > 0) {
+            PointHistory pointHistory = PointHistory.builder()
+                    .customer(customer)
+                    .changeType(PointChangeType.USED)
+                    .amount(dto.getUsedPoints())
+                    .relatedReservationId(reservation.getId())
+                    .build();
+            pointHistoryRepository.save(pointHistory);
+        }
+
+        reservationRepository.save(reservation);
+        log.info("결제 대기 상태의 예매 생성 완료: reservationId={}", reservation.getId());
+
+        return new ReservationResponseDto(reservation, dto.getUsedPoints(), finalAmount, screening.getMovie().getTitle(), seatNumbers);
+    }
+
+    /**
+     * 결제를 완료하고 예매를 확정합니다.
+     * 예매 상태를 COMPLETED로 변경하고, 좌석을 SOLD 상태로 변경하며,
+     * 결제 정보를 저장하고 포인트 적립을 처리합니다.
+     * 
+     * @param dto 결제 정보 (예매 ID, 주문 ID, 결제 키, 결제 방법 등)
+     * @param customerId 결제하는 고객 ID
+     * @throws IllegalArgumentException 예약자 정보가 일치하지 않는 경우
+     * @throws IllegalStateException 이미 처리되었거나 취소된 예약인 경우
+     * @throws EntityNotFoundException 예약 정보를 찾을 수 없는 경우
+     */
+    @Transactional
+    public void completeReservation(PaymentRequestDto dto, Long customerId) {
+        log.info("결제 완료 처리 시작: reservationId={}", dto.getReservationId());
+        Reservation reservation = reservationRepository.findById(dto.getReservationId())
+                .orElseThrow(() -> new EntityNotFoundException("예약 정보를 찾을 수 없습니다: " + dto.getReservationId()));
+
+        if (!reservation.getCustomer().getId().equals(customerId)) {
+            throw new IllegalArgumentException("예약자 정보가 일치하지 않습니다.");
+        }
+        if (reservation.getPaymentStatus() != PaymentStatus.PENDING) {
+            throw new IllegalStateException("이미 처리되었거나 취소된 예약입니다.");
+        }
+
+        reservation.updatePaymentStatus(PaymentStatus.COMPLETED);
+
+        // 티켓 상태 'ISSUED'로 변경 (이미 생성 시 ISSUED로 설정됨)
+        // 좌석 상태 'SOLD'로 변경
+        for (Ticket ticket : reservation.getTickets()) {
+            ScreeningSeat screeningSeat = screeningSeatRepository.findById(new ScreeningSeat.ScreeningSeatId(ticket.getScreeningId(), ticket.getSeatId()))
+                    .orElseThrow(() -> new EntityNotFoundException("좌석 정보를 찾을 수 없습니다."));
+            screeningSeat.setSeatStatus(SeatStatus.SOLD);
+            screeningSeat.setHoldExpiresAt(null);
+        }
+
+        // 사용된 포인트 계산
+        int usedPoints = dto.getUsedPointAmount() != null ? dto.getUsedPointAmount() : 0;
+        int finalAmount = reservation.getTotalAmount() - usedPoints;
+
+        // 포인트 적립 (결제 금액의 10%)
+        int earnedPoints = (int) (finalAmount * 0.1);
+        if (earnedPoints > 0) {
+            Customer customer = reservation.getCustomer();
+            customer.addPoints(earnedPoints);
+            PointHistory pointHistory = PointHistory.builder()
+                    .customer(customer)
+                    .changeType(PointChangeType.EARNED)
+                    .amount(earnedPoints)
+                    .relatedReservationId(reservation.getId())
+                    .build();
+            pointHistoryRepository.save(pointHistory);
+        }
+
+        // 결제 정보 생성
+        Payment payment = Payment.builder()
+                .reservation(reservation)
+                .orderId(dto.getOrderId())
+                .paymentKey(dto.getPaymentKey())
+                .paymentMethod(dto.getPaymentMethod())
+                .paymentStatus("DONE")
+                .currency("KRW")
+                .paymentDiscountId(null)
+                .amount(reservation.getTotalAmount())
+                .usedPointAmount(usedPoints)
+                .finalAmount(finalAmount)
+                .approvedAt(LocalDateTime.now())
+                .build();
+        paymentRepository.save(payment);
+
+        log.info("결제 완료 처리 성공: reservationId={}", reservation.getId());
+    }
+
+    /**
+     * 선점 시간이 만료된 좌석들을 자동으로 해제합니다.
+     * 스케줄러에 의해 주기적으로 호출되어 만료된 HOLD 상태의 좌석들을 AVAILABLE로 변경합니다.
+     * 
+     * @return 해제된 좌석의 개수
+     */
+    @Transactional
+    public int releaseExpiredHeldSeats() {
+        List<ScreeningSeat> expiredSeats = screeningSeatRepository.findAllBySeatStatusAndHoldExpiresAtBefore(SeatStatus.HOLD, LocalDateTime.now());
+        if (expiredSeats.isEmpty()) {
+            return 0;
+        }
+        for (ScreeningSeat seat : expiredSeats) {
+            seat.setSeatStatus(SeatStatus.AVAILABLE);
+            seat.setHoldExpiresAt(null);
+            seat.setHoldCustomerId(null);
+        }
+        return expiredSeats.size();
+    }
+
+    /**
+     * 고객의 예매 내역을 조회합니다.
+     * @param customerId 고객 ID
+     * @return 예매 내역 목록
+     */
+    public List<ReservationResponseDto> getReservationsByCustomerId(Long customerId) {
+        List<Reservation> reservations = reservationRepository.findByCustomerIdOrderByReservationDateDesc(customerId);
+        return reservations.stream()
+                .map(reservation -> {
+                    Screening screening = screeningRepository.findById(reservation.getScreeningId())
+                            .orElse(null);
+                    String movieTitle = screening != null && screening.getMovie() != null ? 
+                                       screening.getMovie().getTitle() : "영화 정보 없음";
+                    
+                    List<String> seatNumbers = reservation.getTickets().stream()
+                            .map(ticket -> {
+                                ScreeningSeat screeningSeat = screeningSeatRepository.findById(
+                                    new ScreeningSeat.ScreeningSeatId(ticket.getScreeningId(), ticket.getSeatId())
+                                ).orElse(null);
+                                return screeningSeat != null ? screeningSeat.getSeat().getSeatNumber() : "좌석 정보 없음";
+                            })
+                            .collect(Collectors.toList());
+                    
+                    int usedPoints = reservation.getPayment() != null ? reservation.getPayment().getUsedPointAmount() : 0;
+                    int finalAmount = reservation.getTotalAmount() - usedPoints;
+                    
+                    return new ReservationResponseDto(reservation, usedPoints, finalAmount, movieTitle, seatNumbers);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/screening/dto/ScreeningSeatStatusDto.java
+++ b/src/main/java/com/uos/picobox/domain/screening/dto/ScreeningSeatStatusDto.java
@@ -1,0 +1,27 @@
+package com.uos.picobox.domain.screening.dto;
+
+import com.uos.picobox.domain.screening.entity.ScreeningSeat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ScreeningSeatStatusDto {
+    @Schema(description = "좌석 고유 ID", example = "101")
+    private Long seatId;
+
+    @Schema(description = "좌석 번호", example = "A1")
+    private String seatNumber;
+
+    @Schema(description = "좌석 상태", example = "AVAILABLE")
+    private String status;
+
+    public static ScreeningSeatStatusDto fromEntity(ScreeningSeat screeningSeat) {
+        return ScreeningSeatStatusDto.builder()
+                .seatId(screeningSeat.getSeat().getId())
+                .seatNumber(screeningSeat.getSeat().getSeatNumber())
+                .status(screeningSeat.getSeatStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/screening/dto/ScreeningSeatsResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/screening/dto/ScreeningSeatsResponseDto.java
@@ -1,0 +1,26 @@
+package com.uos.picobox.domain.screening.dto;
+
+import com.uos.picobox.domain.screening.entity.Screening;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ScreeningSeatsResponseDto {
+
+    @Schema(description = "상영 정보")
+    private ScreeningResponseDto screeningInfo;
+
+    @Schema(description = "좌석 목록")
+    private List<ScreeningSeatStatusDto> seats;
+
+    public static ScreeningSeatsResponseDto toDto(Screening screening, List<ScreeningSeatStatusDto> seats) {
+        return ScreeningSeatsResponseDto.builder()
+                .screeningInfo(new ScreeningResponseDto(screening))
+                .seats(seats)
+                .build();
+    }
+}

--- a/src/main/java/com/uos/picobox/domain/screening/entity/ScreeningSeat.java
+++ b/src/main/java/com/uos/picobox/domain/screening/entity/ScreeningSeat.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -34,6 +35,18 @@ public class ScreeningSeat {
     @Setter
     @Enumerated(EnumType.STRING)
     private SeatStatus seatStatus;
+
+    @Setter
+    @Column(name = "HOLD_EXPIRES_AT")
+    private LocalDateTime holdExpiresAt;
+
+    @Setter
+    @Column(name = "HOLD_CUSTOMER_ID")
+    private Long holdCustomerId;
+
+    @Setter
+    @Column(name = "HOLD_GUEST_ID")
+    private Long holdGuestId;
 
     @Builder
     public ScreeningSeat(Screening screening, Seat seat, SeatStatus seatStatus) {

--- a/src/main/java/com/uos/picobox/domain/screening/repository/ScreeningSeatRepository.java
+++ b/src/main/java/com/uos/picobox/domain/screening/repository/ScreeningSeatRepository.java
@@ -2,10 +2,17 @@ package com.uos.picobox.domain.screening.repository;
 
 import com.uos.picobox.domain.screening.entity.ScreeningSeat;
 import com.uos.picobox.domain.screening.entity.ScreeningSeat.ScreeningSeatId;
+import com.uos.picobox.domain.screening.entity.SeatStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 
 public interface ScreeningSeatRepository extends JpaRepository<ScreeningSeat, ScreeningSeatId> {
@@ -14,4 +21,10 @@ public interface ScreeningSeatRepository extends JpaRepository<ScreeningSeat, Sc
     @Modifying
     @Query("DELETE FROM ScreeningSeat ss WHERE ss.screening.id = :screeningId")
     void deleteAllByScreeningId(@Param("screeningId") Long screeningId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ss FROM ScreeningSeat ss WHERE ss.screening.id = :screeningId AND ss.seat.id = :seatId")
+    Optional<ScreeningSeat> findByIdWithPessimisticLock(@Param("screeningId") Long screeningId, @Param("seatId") Long seatId);
+
+    List<ScreeningSeat> findAllBySeatStatusAndHoldExpiresAtBefore(SeatStatus seatStatus, LocalDateTime now);
 }

--- a/src/main/java/com/uos/picobox/global/scheduler/SeatHoldCleanupScheduler.java
+++ b/src/main/java/com/uos/picobox/global/scheduler/SeatHoldCleanupScheduler.java
@@ -1,0 +1,43 @@
+package com.uos.picobox.global.scheduler;
+
+import com.uos.picobox.domain.screening.entity.ScreeningSeat;
+import com.uos.picobox.domain.screening.entity.SeatStatus;
+import com.uos.picobox.domain.screening.repository.ScreeningSeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatHoldCleanupScheduler {
+    
+    private final ScreeningSeatRepository screeningSeatRepository;
+    
+    /**
+     * 매 1분마다 만료된 좌석 선점을 해제합니다.
+     */
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    @Transactional
+    public void cleanupExpiredHolds() {
+        LocalDateTime now = LocalDateTime.now();
+        List<ScreeningSeat> expiredSeats = screeningSeatRepository
+                .findAllBySeatStatusAndHoldExpiresAtBefore(SeatStatus.HOLD, now);
+        
+        if (!expiredSeats.isEmpty()) {
+            log.info("만료된 좌석 선점 해제: {} 개", expiredSeats.size());
+            
+            for (ScreeningSeat seat : expiredSeats) {
+                seat.setSeatStatus(SeatStatus.AVAILABLE);
+                seat.setHoldExpiresAt(null);
+            }
+            
+            log.info("좌석 선점 해제 완료: {} 개", expiredSeats.size());
+        }
+    }
+} 

--- a/src/main/java/com/uos/picobox/global/utils/SessionUtil.java
+++ b/src/main/java/com/uos/picobox/global/utils/SessionUtil.java
@@ -1,0 +1,61 @@
+package com.uos.picobox.global.utils;
+
+import com.uos.picobox.user.entity.Customer;
+import com.uos.picobox.user.repository.CustomerRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class SessionUtil {
+    
+    private final CacheManager cacheManager;
+    private final CustomerRepository customerRepository;
+    
+    /**
+     * 세션 ID로부터 로그인 ID를 조회합니다.
+     * @param sessionId 세션 ID
+     * @return 로그인 ID
+     * @throws IllegalArgumentException 유효하지 않은 세션인 경우
+     */
+    public String getLoginIdFromSession(String sessionId) {
+        if (sessionId == null || sessionId.trim().isEmpty()) {
+            throw new IllegalArgumentException("세션 ID가 제공되지 않았습니다.");
+        }
+        
+        Cache cache = cacheManager.getCache("customerSession");
+        Cache.ValueWrapper wrapper = Objects.requireNonNull(cache).get(sessionId);
+        
+        if (Objects.isNull(wrapper)) {
+            throw new IllegalArgumentException("유효하지 않거나 만료된 세션입니다.");
+        }
+        
+        return (String) wrapper.get();
+    }
+    
+    /**
+     * 세션 ID로부터 고객 정보를 검증하고 고객 ID를 반환합니다.
+     * @param sessionId 세션 ID
+     * @return 고객 ID
+     */
+    public Long getCustomerIdFromSession(String sessionId) {
+        String loginId = getLoginIdFromSession(sessionId);
+        Customer customer = customerRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new EntityNotFoundException("고객 정보를 찾을 수 없습니다: " + loginId));
+        return customer.getId();
+    }
+    
+    /**
+     * 세션 ID로부터 로그인 ID를 반환합니다.
+     * @param sessionId 세션 ID
+     * @return 로그인 ID
+     */
+    public String getCustomerLoginIdFromSession(String sessionId) {
+        return getLoginIdFromSession(sessionId);
+    }
+} 

--- a/src/main/java/com/uos/picobox/user/entity/Customer.java
+++ b/src/main/java/com/uos/picobox/user/entity/Customer.java
@@ -65,4 +65,15 @@ public class Customer {
         this.lastLoginAt = LocalDateTime.now();
         this.isActive = true;
     }
+
+    public void usePoints(int pointsToUse) {
+        if (this.points < pointsToUse) {
+            throw new IllegalArgumentException("보유 포인트가 부족합니다.");
+        }
+        this.points -= pointsToUse;
+    }
+
+    public void addPoints(int pointsToAdd) {
+        this.points += pointsToAdd;
+    }
 }

--- a/src/main/java/com/uos/picobox/user/repository/CustomerRepository.java
+++ b/src/main/java/com/uos/picobox/user/repository/CustomerRepository.java
@@ -5,9 +5,13 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     boolean existsByLoginId(String loginId);
     boolean existsByEmail(String email);
     @Query("SELECT c.password FROM Customer c WHERE c.loginId = :loginId")
     String findPasswordByLoginId(@Param("loginId") String loginId);
+    
+    Optional<Customer> findByLoginId(String loginId);
 }


### PR DESCRIPTION
- `POST /api/reservations/hold-seats` - 좌석 선점
- `POST /api/reservations/release-seats` - 좌석 해제
- `GET /api/screenings/{id}/seats` - 좌석 상태 조회
- `POST /api/reservations/create` - 예매 생성
- `POST /api/reservations/complete-payment` - 결제 완료
- `GET /api/reservations` - 예매 내역 조회

TODO : 예매(결제) 취소 API, 사용자 이탈 시 처리

상영 id가 있으면 상영 시간이 지났어도 예매가 되긴 하는 상태.
결제 후에 /api/reservations/release 를 하면 성공 응답이 뜨긴 하는데 실제로 해제가 되진 않음 (안건드려도 될듯)
