### PR TITLE
Issue/#48

### DIFF
--- a/src/main/java/com/uos/picobox/client/controller/review/ReviewController.java
+++ b/src/main/java/com/uos/picobox/client/controller/review/ReviewController.java
@@ -1,0 +1,160 @@
+package com.uos.picobox.client.controller.review;
+
+import com.uos.picobox.domain.review.dto.ReviewRequestDto;
+import com.uos.picobox.domain.review.dto.ReviewResponseDto;
+import com.uos.picobox.domain.review.dto.ReviewSummaryDto;
+import com.uos.picobox.domain.review.service.ReviewService;
+import com.uos.picobox.global.utils.SessionUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Tag(name = "리뷰 관리", description = "영화 리뷰 작성, 조회, 수정, 삭제 및 좋아요 기능")
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+    private final SessionUtil sessionUtil;
+
+    @Operation(summary = "리뷰 작성", description = "관람 완료한 영화에 대해 리뷰를 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "리뷰 작성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (관람 미완료, 중복 리뷰 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "예매 또는 영화 정보 없음")
+    })
+    @PostMapping
+    public ResponseEntity<ReviewResponseDto> createReview(
+            @Valid @RequestBody ReviewRequestDto dto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        ReviewResponseDto review = reviewService.createReview(dto, customerId);
+        return ResponseEntity.status(201).body(review);
+    }
+
+    @Operation(summary = "리뷰 수정", description = "본인이 작성한 리뷰를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "리뷰 없음")
+    })
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<ReviewResponseDto> updateReview(
+            @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewRequestDto dto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        ReviewResponseDto review = reviewService.updateReview(reviewId, dto, customerId);
+        return ResponseEntity.ok(review);
+    }
+
+    @Operation(summary = "리뷰 삭제", description = "본인이 작성한 리뷰를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "리뷰 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "리뷰 없음")
+    })
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+            @PathVariable Long reviewId,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        reviewService.deleteReview(reviewId, customerId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "영화별 리뷰 목록 조회", description = "특정 영화의 모든 리뷰를 페이징으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공"),
+            @ApiResponse(responseCode = "204", description = "리뷰 없음")
+    })
+    @GetMapping("/movie/{movieId}")
+    public ResponseEntity<Page<ReviewResponseDto>> getReviewsByMovie(
+            @PathVariable Long movieId,
+            @Parameter(description = "정렬 기준 (latest: 최신순, like: 좋아요순)", example = "latest")
+            @RequestParam(defaultValue = "latest") String sortBy,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String sessionId) {
+        
+        Long currentUserId = null;
+        if (sessionId != null) {
+            try {
+                currentUserId = sessionUtil.getCustomerIdFromSession(sessionId);
+            } catch (Exception e) {
+                // 세션이 유효하지 않으면 null로 처리 (비로그인 사용자)
+            }
+        }
+        
+        Page<ReviewResponseDto> reviews = reviewService.getReviewsByMovie(movieId, sortBy, page, size, currentUserId);
+        
+        if (reviews.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(reviews);
+    }
+
+    @Operation(summary = "영화 리뷰 요약 정보", description = "특정 영화의 평균 평점과 총 리뷰 개수를 조회합니다.")
+    @GetMapping("/movie/{movieId}/summary")
+    public ResponseEntity<ReviewSummaryDto> getReviewSummary(@PathVariable Long movieId) {
+        ReviewSummaryDto summary = reviewService.getReviewSummary(movieId);
+        return ResponseEntity.ok(summary);
+    }
+
+    @Operation(summary = "리뷰 좋아요 토글", description = "리뷰에 좋아요를 추가하거나 제거합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "좋아요 토글 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "리뷰 없음")
+    })
+    @PostMapping("/{reviewId}/like")
+    public ResponseEntity<Map<String, Object>> toggleReviewLike(
+            @PathVariable Long reviewId,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        boolean isLiked = reviewService.toggleReviewLike(reviewId, customerId);
+        
+        return ResponseEntity.ok(Map.of(
+                "isLiked", isLiked,
+                "message", isLiked ? "좋아요를 추가했습니다." : "좋아요를 취소했습니다."
+        ));
+    }
+
+    @Operation(summary = "내가 작성한 리뷰 목록", description = "로그인한 사용자가 작성한 모든 리뷰를 조회합니다.")
+    @GetMapping("/my")
+    public ResponseEntity<Page<ReviewResponseDto>> getMyReviews(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String sessionId) {
+        
+        Long customerId = sessionUtil.getCustomerIdFromSession(sessionId);
+        Page<ReviewResponseDto> reviews = reviewService.getMyReviews(customerId, page, size);
+        
+        if (reviews.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(reviews);
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/reservation/repository/TicketRepository.java
+++ b/src/main/java/com/uos/picobox/domain/reservation/repository/TicketRepository.java
@@ -1,7 +1,18 @@
 package com.uos.picobox.domain.reservation.repository;
 
 import com.uos.picobox.domain.reservation.entity.Ticket;
+import com.uos.picobox.domain.reservation.entity.TicketStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    
+    /**
+     * 특정 상영의 특정 상태 티켓들을 조회합니다.
+     * @param screeningId 상영 ID
+     * @param ticketStatus 티켓 상태
+     * @return 해당 조건의 티켓 목록
+     */
+    List<Ticket> findByScreeningIdAndTicketStatus(Long screeningId, TicketStatus ticketStatus);
 }

--- a/src/main/java/com/uos/picobox/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/uos/picobox/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,39 @@
+package com.uos.picobox.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReviewRequestDto {
+
+    @NotNull(message = "예매 ID는 필수입니다.")
+    @Schema(description = "예매 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long reservationId;
+
+    @NotNull(message = "영화 ID는 필수입니다.")
+    @Schema(description = "영화 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long movieId;
+
+    @NotNull(message = "평점은 필수입니다.")
+    @DecimalMin(value = "0.5", message = "평점은 0.5 이상이어야 합니다.")
+    @DecimalMax(value = "5.0", message = "평점은 5.0 이하여야 합니다.")
+    @Schema(description = "평점 (0.5 단위, 0.5~5.0)", example = "4.5", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Double rating;
+
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    @Size(max = 500, message = "리뷰 내용은 500자 이하여야 합니다.")
+    @Schema(description = "리뷰 내용", example = "정말 재미있는 영화였습니다!", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String comment;
+
+    public ReviewRequestDto(Long reservationId, Long movieId, Double rating, String comment) {
+        this.reservationId = reservationId;
+        this.movieId = movieId;
+        this.rating = rating;
+        this.comment = comment;
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/uos/picobox/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,66 @@
+package com.uos.picobox.domain.review.dto;
+
+import com.uos.picobox.domain.review.entity.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReviewResponseDto {
+
+    @Schema(description = "리뷰 ID", example = "1")
+    private Long reviewId;
+
+    @Schema(description = "예매 ID", example = "123")
+    private Long reservationId;
+
+    @Schema(description = "고객 ID", example = "1")
+    private Long customerId;
+
+    @Schema(description = "고객 로그인 ID", example = "customer123")
+    private String customerLoginId;
+
+    @Schema(description = "영화 ID", example = "1")
+    private Long movieId;
+
+    @Schema(description = "영화 제목", example = "인사이드 아웃 2")
+    private String movieTitle;
+
+    @Schema(description = "평점", example = "4.5")
+    private Double rating;
+
+    @Schema(description = "리뷰 내용", example = "정말 재미있는 영화였습니다!")
+    private String comment;
+
+    @Schema(description = "좋아요 개수", example = "15")
+    private Integer likeCount;
+
+    @Schema(description = "현재 사용자가 좋아요를 눌렀는지 여부", example = "true")
+    private Boolean isLikedByCurrentUser = false;
+
+    @Schema(description = "작성 일시", example = "2024-01-15T14:30:00")
+    private LocalDateTime createdAt;
+
+    public ReviewResponseDto(Review review) {
+        this.reviewId = review.getId();
+        this.reservationId = review.getReservation().getId();
+        this.customerId = review.getCustomer().getId();
+        this.customerLoginId = review.getCustomer().getLoginId();
+        this.movieId = review.getMovie().getId();
+        this.movieTitle = review.getMovie().getTitle();
+        this.rating = review.getRating();
+        this.comment = review.getComment();
+        this.likeCount = review.getLikeCount();
+        this.createdAt = review.getCreatedAt();
+    }
+
+    public ReviewResponseDto(Review review, Boolean isLikedByCurrentUser) {
+        this(review);
+        this.isLikedByCurrentUser = isLikedByCurrentUser;
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/review/dto/ReviewSummaryDto.java
+++ b/src/main/java/com/uos/picobox/domain/review/dto/ReviewSummaryDto.java
@@ -1,0 +1,27 @@
+package com.uos.picobox.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReviewSummaryDto {
+
+    @Schema(description = "영화 ID", example = "1")
+    private Long movieId;
+
+    @Schema(description = "평균 평점", example = "4.2")
+    private Double averageRating;
+
+    @Schema(description = "총 리뷰 개수", example = "42")
+    private Long totalReviews;
+
+    public ReviewSummaryDto(Long movieId, Double averageRating, Long totalReviews) {
+        this.movieId = movieId;
+        this.averageRating = averageRating != null ? Math.round(averageRating * 10.0) / 10.0 : 0.0;
+        this.totalReviews = totalReviews;
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/review/entity/Review.java
+++ b/src/main/java/com/uos/picobox/domain/review/entity/Review.java
@@ -1,0 +1,89 @@
+package com.uos.picobox.domain.review.entity;
+
+import com.uos.picobox.domain.movie.entity.Movie;
+import com.uos.picobox.domain.reservation.entity.Reservation;
+import com.uos.picobox.user.entity.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "REVIEW")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "REVIEW_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "RESERVATION_ID", nullable = false)
+    private Reservation reservation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CUSTOMER_ID", nullable = false)
+    private Customer customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MOVIE_ID", nullable = false)
+    private Movie movie;
+
+    @Column(name = "RATING", nullable = false)
+    private Double rating;
+
+    @Column(name = "REVIEW_COMMENT", nullable = false, length = 500)
+    private String comment;
+
+    @Column(name = "LIKE_COUNT", nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(name = "CREATED_AT", nullable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
+
+    @Builder
+    public Review(Reservation reservation, Customer customer, Movie movie, Double rating, String comment) {
+        this.reservation = reservation;
+        this.customer = customer;
+        this.movie = movie;
+        this.rating = rating;
+        this.comment = comment;
+        this.likeCount = 0;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateReview(Double rating, String comment) {
+        this.rating = rating;
+        this.comment = comment;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+        if (this.likeCount == null) {
+            this.likeCount = 0;
+        }
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/review/entity/ReviewLike.java
+++ b/src/main/java/com/uos/picobox/domain/review/entity/ReviewLike.java
@@ -1,0 +1,72 @@
+package com.uos.picobox.domain.review.entity;
+
+import com.uos.picobox.user.entity.Customer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "REVIEW_LIKE")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(ReviewLike.ReviewLikeId.class)
+public class ReviewLike {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "REVIEW_ID", nullable = false)
+    private Review review;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CUSTOMER_ID", nullable = false)
+    private Customer customer;
+
+    @Column(name = "LIKED_AT", nullable = false)
+    private LocalDateTime likedAt;
+
+    @Builder
+    public ReviewLike(Review review, Customer customer) {
+        this.review = review;
+        this.customer = customer;
+        this.likedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.likedAt == null) {
+            this.likedAt = LocalDateTime.now();
+        }
+    }
+
+    // 복합키 클래스
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ReviewLikeId implements Serializable {
+        private Long review;
+        private Long customer;
+
+        public ReviewLikeId(Long reviewId, Long customerId) {
+            this.review = reviewId;
+            this.customer = customerId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ReviewLikeId that = (ReviewLikeId) o;
+            return Objects.equals(review, that.review) && Objects.equals(customer, that.customer);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(review, customer);
+        }
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/uos/picobox/domain/review/repository/ReviewLikeRepository.java
@@ -1,0 +1,22 @@
+package com.uos.picobox.domain.review.repository;
+
+import com.uos.picobox.domain.review.entity.ReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, ReviewLike.ReviewLikeId> {
+
+    /**
+     * 특정 고객이 특정 리뷰에 좋아요를 눌렀는지 확인
+     */
+    boolean existsByReviewIdAndCustomerId(Long reviewId, Long customerId);
+
+    /**
+     * 특정 고객이 특정 리뷰에 누른 좋아요 삭제
+     */
+    void deleteByReviewIdAndCustomerId(Long reviewId, Long customerId);
+
+    /**
+     * 특정 리뷰의 좋아요 개수
+     */
+    long countByReviewId(Long reviewId);
+} 

--- a/src/main/java/com/uos/picobox/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/uos/picobox/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,52 @@
+package com.uos.picobox.domain.review.repository;
+
+import com.uos.picobox.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    /**
+     * 특정 고객이 특정 영화에 대해 작성한 리뷰 조회 (한 영화당 하나의 리뷰)
+     */
+    Optional<Review> findByCustomerIdAndMovieId(Long customerId, Long movieId);
+
+    /**
+     * 특정 고객이 특정 영화에 대해 리뷰를 작성했는지 확인
+     */
+    boolean existsByCustomerIdAndMovieId(Long customerId, Long movieId);
+
+    /**
+     * 특정 영화의 모든 리뷰를 페이징으로 조회 (최신순)
+     */
+    @Query("SELECT r FROM Review r WHERE r.movie.id = :movieId ORDER BY r.createdAt DESC")
+    Page<Review> findByMovieIdOrderByCreatedAtDesc(@Param("movieId") Long movieId, Pageable pageable);
+
+    /**
+     * 특정 영화의 모든 리뷰를 페이징으로 조회 (좋아요순)
+     */
+    @Query("SELECT r FROM Review r WHERE r.movie.id = :movieId ORDER BY r.likeCount DESC, r.createdAt DESC")
+    Page<Review> findByMovieIdOrderByLikeCountDesc(@Param("movieId") Long movieId, Pageable pageable);
+
+    /**
+     * 특정 영화의 평균 평점 계산
+     */
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.movie.id = :movieId")
+    Double calculateAverageRatingByMovieId(@Param("movieId") Long movieId);
+
+    /**
+     * 특정 영화의 총 리뷰 개수
+     */
+    long countByMovieId(Long movieId);
+
+    /**
+     * 특정 고객이 작성한 모든 리뷰 조회 (최신순)
+     */
+    @Query("SELECT r FROM Review r WHERE r.customer.id = :customerId ORDER BY r.createdAt DESC")
+    Page<Review> findByCustomerIdOrderByCreatedAtDesc(@Param("customerId") Long customerId, Pageable pageable);
+} 

--- a/src/main/java/com/uos/picobox/domain/review/service/ReviewService.java
+++ b/src/main/java/com/uos/picobox/domain/review/service/ReviewService.java
@@ -1,0 +1,229 @@
+package com.uos.picobox.domain.review.service;
+
+import com.uos.picobox.domain.movie.entity.Movie;
+import com.uos.picobox.domain.movie.repository.MovieRepository;
+import com.uos.picobox.domain.reservation.entity.Reservation;
+import com.uos.picobox.domain.reservation.entity.Ticket;
+import com.uos.picobox.domain.reservation.entity.TicketStatus;
+import com.uos.picobox.domain.reservation.repository.ReservationRepository;
+import com.uos.picobox.domain.screening.entity.Screening;
+import com.uos.picobox.domain.screening.repository.ScreeningRepository;
+import com.uos.picobox.domain.review.dto.ReviewRequestDto;
+import com.uos.picobox.domain.review.dto.ReviewResponseDto;
+import com.uos.picobox.domain.review.dto.ReviewSummaryDto;
+import com.uos.picobox.domain.review.entity.Review;
+import com.uos.picobox.domain.review.entity.ReviewLike;
+import com.uos.picobox.domain.review.repository.ReviewLikeRepository;
+import com.uos.picobox.domain.review.repository.ReviewRepository;
+import com.uos.picobox.user.entity.Customer;
+import com.uos.picobox.user.repository.CustomerRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+    private final ReservationRepository reservationRepository;
+    private final CustomerRepository customerRepository;
+    private final MovieRepository movieRepository;
+    private final ScreeningRepository screeningRepository;
+
+    /**
+     * 리뷰 작성 - 관람 완료한 영화에 대해서만 작성 가능
+     */
+    @Transactional
+    public ReviewResponseDto createReview(ReviewRequestDto dto, Long customerId) {
+        Customer customer = customerRepository.findById(customerId)
+                .orElseThrow(() -> new EntityNotFoundException("고객 정보를 찾을 수 없습니다: " + customerId));
+
+        Movie movie = movieRepository.findById(dto.getMovieId())
+                .orElseThrow(() -> new EntityNotFoundException("영화 정보를 찾을 수 없습니다: " + dto.getMovieId()));
+
+        Reservation reservation = reservationRepository.findById(dto.getReservationId())
+                .orElseThrow(() -> new EntityNotFoundException("예매 정보를 찾을 수 없습니다: " + dto.getReservationId()));
+
+        // 예매자가 본인인지 확인
+        if (!reservation.getCustomer().getId().equals(customerId)) {
+            throw new IllegalArgumentException("본인의 예매에 대해서만 리뷰를 작성할 수 있습니다.");
+        }
+
+        // 관람 완료 확인 (상영 시작 후 10분이 지났는지 확인 또는 티켓이 USED 상태인지 확인)
+        Screening screening = reservation.getTickets().isEmpty() ? null : 
+            screeningRepository.findById(reservation.getTickets().get(0).getScreeningId()).orElse(null);
+        
+        if (screening == null) {
+            throw new IllegalStateException("상영 정보를 찾을 수 없습니다.");
+        }
+        
+        // 티켓이 USED 상태이거나 상영 시작 후 10분이 지났으면 리뷰 작성 가능
+        boolean hasUsedTicket = reservation.getTickets().stream()
+                .anyMatch(ticket -> ticket.getTicketStatus() == TicketStatus.USED);
+        
+        LocalDateTime screeningStartPlus10Min = screening.getScreeningTime().plusMinutes(10);
+        boolean screeningStarted = LocalDateTime.now().isAfter(screeningStartPlus10Min);
+        
+        if (!hasUsedTicket && !screeningStarted) {
+            throw new IllegalStateException("상영 시작 후 10분이 지난 후에 리뷰를 작성할 수 있습니다.");
+        }
+
+        // 이미 해당 영화에 대한 리뷰가 있는지 확인 (한 영화당 하나의 리뷰)
+        if (reviewRepository.existsByCustomerIdAndMovieId(customerId, dto.getMovieId())) {
+            throw new IllegalStateException("이미 해당 영화에 대한 리뷰를 작성하셨습니다. 기존 리뷰를 수정해주세요.");
+        }
+
+        // 평점 유효성 검사 (0.5 단위)
+        if (!isValidRating(dto.getRating())) {
+            throw new IllegalArgumentException("평점은 0.5 단위로 0.5~5.0 사이의 값이어야 합니다.");
+        }
+
+        Review review = Review.builder()
+                .reservation(reservation)
+                .customer(customer)
+                .movie(movie)
+                .rating(dto.getRating())
+                .comment(dto.getComment())
+                .build();
+
+        Review savedReview = reviewRepository.save(review);
+        log.info("리뷰 작성 완료: reviewId={}, customerId={}, movieId={}", savedReview.getId(), customerId, dto.getMovieId());
+
+        return new ReviewResponseDto(savedReview);
+    }
+
+    /**
+     * 리뷰 수정
+     */
+    @Transactional
+    public ReviewResponseDto updateReview(Long reviewId, ReviewRequestDto dto, Long customerId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("리뷰를 찾을 수 없습니다: " + reviewId));
+
+        // 작성자 본인인지 확인
+        if (!review.getCustomer().getId().equals(customerId)) {
+            throw new IllegalArgumentException("본인이 작성한 리뷰만 수정할 수 있습니다.");
+        }
+
+        // 평점 유효성 검사
+        if (!isValidRating(dto.getRating())) {
+            throw new IllegalArgumentException("평점은 0.5 단위로 0.5~5.0 사이의 값이어야 합니다.");
+        }
+
+        review.updateReview(dto.getRating(), dto.getComment());
+        log.info("리뷰 수정 완료: reviewId={}, customerId={}", reviewId, customerId);
+
+        return new ReviewResponseDto(review);
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @Transactional
+    public void deleteReview(Long reviewId, Long customerId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("리뷰를 찾을 수 없습니다: " + reviewId));
+
+        // 작성자 본인인지 확인
+        if (!review.getCustomer().getId().equals(customerId)) {
+            throw new IllegalArgumentException("본인이 작성한 리뷰만 삭제할 수 있습니다.");
+        }
+
+        reviewRepository.delete(review);
+        log.info("리뷰 삭제 완료: reviewId={}, customerId={}", reviewId, customerId);
+    }
+
+    /**
+     * 특정 영화의 리뷰 목록 조회 (페이징, 정렬)
+     */
+    public Page<ReviewResponseDto> getReviewsByMovie(Long movieId, String sortBy, int page, int size, Long currentUserId) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Review> reviews;
+
+        if ("like".equals(sortBy)) {
+            reviews = reviewRepository.findByMovieIdOrderByLikeCountDesc(movieId, pageable);
+        } else {
+            reviews = reviewRepository.findByMovieIdOrderByCreatedAtDesc(movieId, pageable);
+        }
+
+        return reviews.map(review -> {
+            boolean isLiked = currentUserId != null && 
+                    reviewLikeRepository.existsByReviewIdAndCustomerId(review.getId(), currentUserId);
+            return new ReviewResponseDto(review, isLiked);
+        });
+    }
+
+    /**
+     * 영화별 리뷰 요약 정보 조회 (평균 평점, 총 리뷰 수)
+     */
+    public ReviewSummaryDto getReviewSummary(Long movieId) {
+        Double averageRating = reviewRepository.calculateAverageRatingByMovieId(movieId);
+        Long totalReviews = reviewRepository.countByMovieId(movieId);
+        
+        return new ReviewSummaryDto(movieId, averageRating, totalReviews);
+    }
+
+    /**
+     * 리뷰 좋아요 토글 (추가/제거)
+     */
+    @Transactional
+    public boolean toggleReviewLike(Long reviewId, Long customerId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("리뷰를 찾을 수 없습니다: " + reviewId));
+
+        Customer customer = customerRepository.findById(customerId)
+                .orElseThrow(() -> new EntityNotFoundException("고객 정보를 찾을 수 없습니다: " + customerId));
+
+        boolean alreadyLiked = reviewLikeRepository.existsByReviewIdAndCustomerId(reviewId, customerId);
+
+        if (alreadyLiked) {
+            // 좋아요 제거
+            reviewLikeRepository.deleteByReviewIdAndCustomerId(reviewId, customerId);
+            review.decreaseLikeCount();
+            log.info("리뷰 좋아요 제거: reviewId={}, customerId={}", reviewId, customerId);
+            return false;
+        } else {
+            // 좋아요 추가
+            ReviewLike reviewLike = ReviewLike.builder()
+                    .review(review)
+                    .customer(customer)
+                    .build();
+            reviewLikeRepository.save(reviewLike);
+            review.increaseLikeCount();
+            log.info("리뷰 좋아요 추가: reviewId={}, customerId={}", reviewId, customerId);
+            return true;
+        }
+    }
+
+    /**
+     * 내가 작성한 리뷰 목록 조회
+     */
+    public Page<ReviewResponseDto> getMyReviews(Long customerId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Review> reviews = reviewRepository.findByCustomerIdOrderByCreatedAtDesc(customerId, pageable);
+        
+        return reviews.map(review -> new ReviewResponseDto(review, false));
+    }
+
+    /**
+     * 평점 유효성 검사 (0.5 단위)
+     */
+    private boolean isValidRating(Double rating) {
+        if (rating == null || rating < 0.5 || rating > 5.0) {
+            return false;
+        }
+        // 0.5 단위인지 확인
+        return (rating * 10) % 5 == 0;
+    }
+} 

--- a/src/main/java/com/uos/picobox/domain/screening/repository/ScreeningRepository.java
+++ b/src/main/java/com/uos/picobox/domain/screening/repository/ScreeningRepository.java
@@ -47,28 +47,40 @@ public interface ScreeningRepository extends JpaRepository<Screening, Long> {
 
     /**
      * 사용자용: 특정 날짜의 모든 상영 스케줄을 조회합니다. (시간 오름차순 정렬)
+     * 상영 시작 후 10분까지는 예매 가능합니다.
      * @param date 조회할 날짜
-     * @return 해당 날짜의 모든 상영 스케줄 목록
+     * @param currentDateTimeMinus10Min 현재 시간 - 10분 (이 시간 이후 시작 상영만 조회)
+     * @return 해당 날짜의 모든 상영 스케줄 목록 (예매 가능한 상영만)
      */
     @Query("SELECT DISTINCT s FROM Screening s " +
             "JOIN FETCH s.movie m " +
             "JOIN FETCH s.screeningRoom sr " +
             "LEFT JOIN FETCH s.screeningSeats ss " +
-            "WHERE s.screeningDate = :date " +
+            "WHERE s.screeningDate = :date AND s.screeningTime > :currentDateTimeMinus10Min " +
             "ORDER BY s.screeningTime ASC")
-    List<Screening> findByScreeningDateForUser(@Param("date") LocalDate date);
+    List<Screening> findByScreeningDateForUser(@Param("date") LocalDate date, @Param("currentDateTimeMinus10Min") java.time.LocalDateTime currentDateTimeMinus10Min);
 
     /**
      * 사용자용: 특정 영화의 특정 날짜 상영 스케줄을 조회합니다. (시간 오름차순 정렬)
+     * 상영 시작 후 10분까지는 예매 가능합니다.
      * @param movieId 영화 ID
      * @param date 조회할 날짜
-     * @return 해당 영화, 해당 날짜의 상영 스케줄 목록
+     * @param currentDateTimeMinus10Min 현재 시간 - 10분 (이 시간 이후 시작 상영만 조회)
+     * @return 해당 영화, 해당 날짜의 상영 스케줄 목록 (예매 가능한 상영만)
      */
     @Query("SELECT DISTINCT s FROM Screening s " +
             "JOIN FETCH s.movie m " +
             "JOIN FETCH s.screeningRoom sr " +
             "LEFT JOIN FETCH s.screeningSeats ss " +
-            "WHERE m.id = :movieId AND s.screeningDate = :date " +
+            "WHERE m.id = :movieId AND s.screeningDate = :date AND s.screeningTime > :currentDateTimeMinus10Min " +
             "ORDER BY s.screeningTime ASC")
-    List<Screening> findByMovieIdAndScreeningDateForUser(@Param("movieId") Long movieId, @Param("date") LocalDate date);
+    List<Screening> findByMovieIdAndScreeningDateForUser(@Param("movieId") Long movieId, @Param("date") LocalDate date, @Param("currentDateTimeMinus10Min") java.time.LocalDateTime currentDateTimeMinus10Min);
+
+    /**
+     * 스케줄러용: 지정된 시간 이전에 시작한 상영들을 조회합니다.
+     * @param dateTime 기준 시간
+     * @return 해당 시간 이전에 시작한 상영 목록
+     */
+    @Query("SELECT s FROM Screening s WHERE s.screeningTime < :dateTime")
+    List<Screening> findScreeningsStartedBefore(@Param("dateTime") java.time.LocalDateTime dateTime);
 }

--- a/src/main/java/com/uos/picobox/domain/screening/service/ScreeningService.java
+++ b/src/main/java/com/uos/picobox/domain/screening/service/ScreeningService.java
@@ -220,11 +220,13 @@ public class ScreeningService {
 
     /**
      * 특정 날짜의 모든 상영 스케줄 목록을 조회합니다.
+     * 상영 시작 후 10분까지는 예매 가능합니다.
      * @param date 조회할 날짜
-     * @return 해당 날짜의 상영 스케줄 목록
+     * @return 해당 날짜의 상영 스케줄 목록 (예매 가능한 상영만)
      */
     public List<ScreeningScheduleResponseDto> getScreeningSchedulesByDate(LocalDate date) {
-        List<Screening> screenings = screeningRepository.findByScreeningDateForUser(date);
+        LocalDateTime currentDateTimeMinus10Min = LocalDateTime.now().minusMinutes(10);
+        List<Screening> screenings = screeningRepository.findByScreeningDateForUser(date, currentDateTimeMinus10Min);
         return screenings.stream()
                 .map(ScreeningScheduleResponseDto::new)
                 .collect(Collectors.toList());
@@ -232,12 +234,14 @@ public class ScreeningService {
 
     /**
      * 특정 영화의 특정 날짜 상영 스케줄 목록을 조회합니다.
+     * 상영 시작 후 10분까지는 예매 가능합니다.
      * @param movieId 영화 ID
      * @param date 조회할 날짜
-     * @return 해당 영화, 해당 날짜의 상영 스케줄 목록
+     * @return 해당 영화, 해당 날짜의 상영 스케줄 목록 (예매 가능한 상영만)
      */
     public List<ScreeningScheduleResponseDto> getScreeningSchedulesByMovieAndDate(Long movieId, LocalDate date) {
-        List<Screening> screenings = screeningRepository.findByMovieIdAndScreeningDateForUser(movieId, date);
+        LocalDateTime currentDateTimeMinus10Min = LocalDateTime.now().minusMinutes(10);
+        List<Screening> screenings = screeningRepository.findByMovieIdAndScreeningDateForUser(movieId, date, currentDateTimeMinus10Min);
         return screenings.stream()
                 .map(ScreeningScheduleResponseDto::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/uos/picobox/global/scheduler/TicketStatusUpdateScheduler.java
+++ b/src/main/java/com/uos/picobox/global/scheduler/TicketStatusUpdateScheduler.java
@@ -1,0 +1,54 @@
+package com.uos.picobox.global.scheduler;
+
+import com.uos.picobox.domain.reservation.entity.Ticket;
+import com.uos.picobox.domain.reservation.entity.TicketStatus;
+import com.uos.picobox.domain.reservation.repository.TicketRepository;
+import com.uos.picobox.domain.screening.entity.Screening;
+import com.uos.picobox.domain.screening.repository.ScreeningRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TicketStatusUpdateScheduler {
+
+    private final TicketRepository ticketRepository;
+    private final ScreeningRepository screeningRepository;
+
+    /**
+     * 매 10분마다 실행되어 상영 시작 후 10분이 지난 티켓들을 USED 상태로 변경합니다.
+     */
+    @Scheduled(fixedRate = 600000) // 10분 = 600,000ms
+    @Transactional
+    public void updateTicketsToUsed() {
+        LocalDateTime currentTime = LocalDateTime.now();
+        LocalDateTime tenMinutesAgo = currentTime.minusMinutes(10);
+        
+        // 상영 시작 후 10분이 지난 상영들을 조회
+        List<Screening> screeningsToUpdate = screeningRepository.findScreeningsStartedBefore(tenMinutesAgo);
+        
+        int updatedCount = 0;
+        
+        for (Screening screening : screeningsToUpdate) {
+            // 해당 상영의 ISSUED 상태 티켓들을 USED로 변경
+            List<Ticket> issuedTickets = ticketRepository.findByScreeningIdAndTicketStatus(
+                screening.getId(), TicketStatus.ISSUED);
+            
+            for (Ticket ticket : issuedTickets) {
+                ticket.updateStatus(TicketStatus.USED);
+                updatedCount++;
+            }
+        }
+        
+        if (updatedCount > 0) {
+            log.info("티켓 상태 자동 업데이트 완료: {}개 티켓을 USED로 변경", updatedCount);
+        }
+    }
+} 


### PR DESCRIPTION
# 🎬 영화 리뷰 시스템 및 상영 시간 기반 예매/리뷰 로직 구현

## 📋 구현 내용

### 🌟 주요 기능
- **영화 리뷰 시스템**: 완전한 CRUD 기능 및 좋아요 시스템
- **상영 시간 기반 예매 제한**: 상영 시작 후 10분까지 예매 가능
- **상영 시간 기반 리뷰 작성**: 상영 시작 후 10분부터 리뷰 작성 가능
- **자동 티켓 상태 관리**: 스케줄러를 통한 자동 USED 상태 변경

### 🎯 리뷰 시스템
- **리뷰 작성**: 관람 완료 검증 후 작성 (한 영화당 하나)
- **리뷰 수정/삭제**: 본인 작성 리뷰만 가능
- **리뷰 조회**: 영화별 리뷰 목록 (최신순/좋아요순, 페이징)
- **좋아요 기능**: 리뷰 좋아요/취소 토글
- **평점 시스템**: 0.5 단위 평점 (0.5~5.0)
- **리뷰 요약**: 영화별 평균 평점 및 총 리뷰 수

### ⏰ 시간 기반 로직
- **예매 가능 시간**: 상영 시작 후 10분까지 예매 가능
- **리뷰 작성 시간**: 상영 시작 후 10분부터 리뷰 작성 가능
- **자동 처리**: 매 10분마다 스케줄러가 티켓 상태를 USED로 변경

## 🚀 API 엔드포인트

### 리뷰 관련
- `POST /api/reviews` - 리뷰 작성
- `PUT /api/reviews/{id}` - 리뷰 수정
- `DELETE /api/reviews/{id}` - 리뷰 삭제
- `GET /api/reviews/movie/{movieId}` - 영화별 리뷰 목록
- `GET /api/reviews/movie/{movieId}/summary` - 리뷰 요약 정보
- `POST /api/reviews/{reviewId}/like` - 좋아요 토글
- `GET /api/reviews/my` - 내 리뷰 목록

### 상영 관련 (수정됨)
- `GET /api/screenings?date=yyyy-MM-dd` - 예매 가능한 상영 목록
- `GET /api/movies/{movieId}/screenings?date=yyyy-MM-dd` - 영화별 예매 가능한 상영 목록

## 🧪 테스트 시나리오
1. 상영 시작 전: 예매 가능, 리뷰 작성 불가
2. 상영 시작 후 10분 이내: 예매 가능, 리뷰 작성 불가
3. 상영 시작 후 10분 이후: 예매 불가, 리뷰 작성 가능

## 📊 DB 변경사항
- REVIEW 테이블의 comment 컬럼을 REVIEW_COMMENT로 변경