### PR TITLE
[Feat] 인증 로직 구현 / 관리자, 비회원 가입, 로그인, 로그아웃 API

### DIFF
--- a/src/main/java/com/uos/picobox/BePicoboxApplication.java
+++ b/src/main/java/com/uos/picobox/BePicoboxApplication.java
@@ -2,7 +2,9 @@ package com.uos.picobox;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BePicoboxApplication {
 

--- a/src/main/java/com/uos/picobox/admin/controller/account/AdminSignController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/account/AdminSignController.java
@@ -1,9 +1,10 @@
-package com.uos.picobox.user.controller;
+package com.uos.picobox.admin.controller.account;
 
+import com.uos.picobox.admin.service.AdminSigninService;
+import com.uos.picobox.admin.service.AdminSignoutService;
 import com.uos.picobox.user.dto.SigninRequestDto;
 import com.uos.picobox.user.dto.SigninResponseDto;
 import com.uos.picobox.user.dto.SignoutResponseDto;
-import com.uos.picobox.user.service.SigninService;
 import com.uos.picobox.user.service.SignoutService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,39 +18,39 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "회원 - 01. 로그인, 로그아웃", description = "회원 정보를 처리합니다.")
+@Tag(name = "관리자 - 00. 로그인, 로그아웃", description = "관리자 로그인, 로그아웃을 수행합니다.")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class SignController {
-    private final SigninService signinService;
-    private final SignoutService signoutService;
+public class AdminSignController {
+    private final AdminSigninService adminSigninService;
+    private final AdminSignoutService adminSignoutService;
 
-    @Operation(summary = "회원 로그인", description = "회원 로그인을 처리합니다.")
+    @Operation(summary = "관리자 로그인", description = "관리자 로그인을 처리합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 로그인을 성공했습니다."),
+            @ApiResponse(responseCode = "200", description = "관리자 로그인을 성공했습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 올바르지 못한 loginId or Password)."),
             @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
     })
-    @PostMapping("/signin/customer")
+    @PostMapping("/signin/admin")
     public ResponseEntity<?> signin(
             @Valid @RequestBody SigninRequestDto signinRequestDto) {
-        SigninResponseDto response = signinService.signinCustomer(signinRequestDto);
+        SigninResponseDto response = adminSigninService.signinAdmin(signinRequestDto);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "회원 로그아웃", description = "회원 로그아웃을 처리합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @Operation(summary = "관리자 로그아웃", description = "관리자 로그아웃을 처리합니다.", security = @SecurityRequirement(name = "sessionAuth"))
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 로그아웃을 성공했습니다."),
+            @ApiResponse(responseCode = "200", description = "관리자 로그아웃을 성공했습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 올바르지 못한 sessionId or 만료된 sessionId)."),
             @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
     })
-    @PostMapping("/signout/customer")
+    @PostMapping("/signout/admin")
     public ResponseEntity<?> signout(
             @Parameter(hidden = true)
             @RequestHeader("Authorization") String sessionId
     ) {
-        SignoutResponseDto response = signoutService.signoutCustomer(sessionId);
+        SignoutResponseDto response = adminSignoutService.signoutAdmin(sessionId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/uos/picobox/admin/controller/account/AdminSigninController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/account/AdminSigninController.java
@@ -1,4 +1,0 @@
-package com.uos.picobox.admin.controller.account;
-
-public class AdminSigninController {
-}

--- a/src/main/java/com/uos/picobox/admin/controller/account/AdminSignupController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/account/AdminSignupController.java
@@ -1,4 +1,123 @@
 package com.uos.picobox.admin.controller.account;
 
+import com.uos.picobox.admin.dto.AdminSignupRequestDto;
+import com.uos.picobox.admin.dto.AdminSignupResponseDto;
+import com.uos.picobox.admin.service.AdminSignupService;
+import com.uos.picobox.global.service.EmailService;
+import com.uos.picobox.user.dto.AuthMailRequestDto;
+import com.uos.picobox.user.dto.MailRequestDto;
+import com.uos.picobox.user.dto.SignupRequestDto;
+import com.uos.picobox.user.dto.SignupResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "관리자 - 00. 회원 가입", description = "관리자 회원가입 관련 API를 제공합니다.")
+@RestController
+@RequestMapping("/api/signup/admin")
+@RequiredArgsConstructor
 public class AdminSignupController {
+
+    private final AdminSignupService adminSignupService;
+    private final EmailService emailService;
+
+    @Operation(summary = "회원가입", description = "새로운 관리자를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "새로운 관리자가 성공적으로 등록되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 관리자 정보)."),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+    })
+    @PostMapping("")
+    public ResponseEntity<?> signup(
+            @Valid @RequestBody AdminSignupRequestDto adminSignupRequestDto) {
+        if (!adminSignupRequestDto.getPassword().equals(adminSignupRequestDto.getRepeatPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+        AdminSignupResponseDto response = adminSignupService.registerAdmin(adminSignupRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Validated
+    @Operation(summary = "로그인ID 중복 검사", description = "로그인ID 중복 여부를 검사합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용할 수 있는 로그인ID입니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 로그인ID)."),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+    })
+    @GetMapping("/check/loginid")
+    public ResponseEntity<?> checkLoginId(
+            @RequestParam
+            @NotBlank
+            @Size(min = 1, max = 12, message = "1~12자 사이여야 합니다.")
+            @Schema(description = "로그인 아이디", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
+            String loginId) {
+        boolean response = adminSignupService.isLoginIdAvailable(loginId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Validated
+    @Operation(summary = "이메일 중복 검사", description = "이메일 중복 여부를 검사합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용할 수 있는 이메일입니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 이메일)."),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+    })
+    @GetMapping("/check/email")
+    public ResponseEntity<?> checkEmail(
+            @RequestParam
+            @NotBlank
+            @Email(message = "이메일 형식이어야 합니다.")
+            @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+            String email) {
+        boolean response = adminSignupService.isEmailAvailable(email);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "이메일 인증 코드 전송", description = "이메일 인증 코드를 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 인증 메일을 전송했습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 이메일)."),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+    })
+    @PostMapping("/verify/email")
+    public ResponseEntity<?> verifyEmail(
+            @RequestBody
+            @Valid
+            MailRequestDto mailRequestDto) throws MessagingException {
+        if (!adminSignupService.isEmailAvailable(mailRequestDto.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.");
+        }
+        emailService.sendAuthMail(mailRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Operation(summary = "이메일 인증 코드 인증", description = "이메일 인증 코드를 검증합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "올바른 이메일 인증 코드입니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 이메일, 인증 실패)."),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
+    })
+    @PostMapping("/auth/email")
+    public ResponseEntity<?> authEmail(
+            @RequestBody
+            @Valid
+            AuthMailRequestDto authMailRequestDto) {
+        if (!adminSignupService.isEmailAvailable(authMailRequestDto.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.");
+        }
+        emailService.checkAuthCode(authMailRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/com/uos/picobox/admin/controller/account/AdminSingoutController.java
+++ b/src/main/java/com/uos/picobox/admin/controller/account/AdminSingoutController.java
@@ -1,4 +1,0 @@
-package com.uos.picobox.admin.controller.account;
-
-public class AdminSingoutController {
-}

--- a/src/main/java/com/uos/picobox/admin/dto/AdminSignupRequestDto.java
+++ b/src/main/java/com/uos/picobox/admin/dto/AdminSignupRequestDto.java
@@ -1,0 +1,70 @@
+package com.uos.picobox.admin.dto;
+
+import com.uos.picobox.admin.entity.Admin;
+import com.uos.picobox.global.enumClass.AdminRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminSignupRequestDto {
+    @Schema(description = "로그인 아이디", example = "admin123", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 12, message = "1~12자 사이여야 합니다.")
+    private String loginId;
+
+    /*@Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#\\$%^&*()_+\\-={}:;\"'<>?,./]).+$",
+            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+    ) */
+    @Schema(description = "비밀번호", example = "P@ssw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Size(min = 4, max = 20, message = "비밀번호는 4자 이상 20자 이하이어야 합니다.")
+    private String password;
+
+    @Schema(description = "비밀번호 확인", example = "P@ssw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String repeatPassword;
+
+    @Schema(description = "이름", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String name;
+
+    @Schema(description = "이메일 주소", example = "admin@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Email(message = "이메일 형식이어야 합니다.")
+    private String email;
+
+    @Schema(
+            description = "관리자 권한 등급 (SUPER: 전체 권한, USER_MANAGE: 유저 관리, MOVIE_MANAGE: 영화 관리, SCREEN_MANAGE: 상영 관리)",
+            example = "SUPER",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull
+    private AdminRole role;
+
+    @Schema(
+        description = "관리자 등록 코드 (시스템에서 발급된 랜덤 문자열), 실제 코드도 이것과 같아요.",
+        example = "ABCD1234",
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank
+    private String adminCode;
+
+    public Admin toEntity(String encodedPassword) {
+        return Admin.builder()
+                .loginId(this.loginId)
+                .password(encodedPassword)
+                .name(this.name)
+                .email(this.email)
+                .role(this.role)
+                .build();
+    }
+}

--- a/src/main/java/com/uos/picobox/admin/dto/AdminSignupResponseDto.java
+++ b/src/main/java/com/uos/picobox/admin/dto/AdminSignupResponseDto.java
@@ -1,0 +1,53 @@
+package com.uos.picobox.admin.dto;
+
+import com.uos.picobox.admin.entity.Admin;
+import com.uos.picobox.global.enumClass.AdminRole;
+import com.uos.picobox.user.entity.Customer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class AdminSignupResponseDto {
+    @Schema(description = "고객 고유 ID", example = "1")
+    private Long adminId;
+
+    @Schema(description = "로그인 아이디", example = "user123")
+    private String loginId;
+
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "이메일 주소", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "가입일", example = "2024-01-01T10:00:00")
+    private LocalDateTime registeredAt;
+
+    @Schema(description = "마지막 로그인 일시", example = "2024-04-10T14:00:00")
+    private LocalDateTime lastLoginAt;
+
+    @Schema(
+            description = "관리자 권한 등급 (SUPER: 전체 권한, USER_MANAGE: 유저 관리, MOVIE_MANAGE: 영화 관리, SCREEN_MANAGE: 상영 관리)",
+            example = "SUPER",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private AdminRole role;
+
+    @Schema(description = "활성 상태", example = "true")
+    private Boolean isActive;
+
+    public AdminSignupResponseDto(Admin admin) {
+        this.adminId = admin.getId();
+        this.loginId = admin.getLoginId();
+        this.name = admin.getName();
+        this.email = admin.getEmail();
+        this.registeredAt = admin.getRegisteredAt();
+        this.lastLoginAt = admin.getLastLoginAt();
+        this.isActive = admin.getIsActive();
+        this.role = admin.getRole();
+    }
+}

--- a/src/main/java/com/uos/picobox/admin/entity/Admin.java
+++ b/src/main/java/com/uos/picobox/admin/entity/Admin.java
@@ -1,0 +1,69 @@
+package com.uos.picobox.admin.entity;
+
+import com.uos.picobox.global.converter.AdminRoleConverter;
+import com.uos.picobox.global.converter.BooleanToYNConverter;
+import com.uos.picobox.global.enumClass.AdminRole;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ADMIN")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ADMIN_ID")
+    private Long id;
+
+    @Column(name = "LOGIN_ID", nullable = false, unique = true, length = 50)
+    @NotBlank
+    private String loginId;
+
+    @Column(name = "PASSWORD", nullable = false, length = 128)
+    @NotBlank
+    private String password;
+
+    @Column(name = "NAME", nullable = false, length = 50)
+    @NotBlank
+    private String name;
+
+    @Column(name = "EMAIL", nullable = false, unique = true, length = 100)
+    @Email
+    @NotBlank
+    private String email;
+
+    @Column(name = "REGISTERED_AT", nullable = false)
+    private LocalDateTime registeredAt;
+
+    @Column(name = "LAST_LOGIN_AT")
+    private LocalDateTime lastLoginAt;
+
+    @Convert(converter = AdminRoleConverter.class)
+    @Column(name = "ROLE", nullable = false, length = 20)
+    @NotNull
+    private AdminRole role;
+
+    @Column(name = "IS_ACTIVE", nullable = false, length = 1)
+    @Convert(converter = BooleanToYNConverter.class)
+    private Boolean isActive;
+
+    @Builder
+    public Admin(String loginId, String password, String name, String email, AdminRole role) {
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.registeredAt = LocalDateTime.now();
+        this.lastLoginAt = LocalDateTime.now();
+        this.role = role;
+        this.isActive = true;
+    }
+}

--- a/src/main/java/com/uos/picobox/admin/repository/AdminRepository.java
+++ b/src/main/java/com/uos/picobox/admin/repository/AdminRepository.java
@@ -1,0 +1,13 @@
+package com.uos.picobox.admin.repository;
+
+import com.uos.picobox.admin.entity.Admin;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    boolean existsByLoginId(String loginId);
+    boolean existsByEmail(String email);
+    @Query("SELECT a.password FROM Admin a WHERE a.loginId = :loginId")
+    String findPasswordByLoginId(@Param("loginId") String loginId);
+}

--- a/src/main/java/com/uos/picobox/admin/service/AdminSigninService.java
+++ b/src/main/java/com/uos/picobox/admin/service/AdminSigninService.java
@@ -1,9 +1,9 @@
-package com.uos.picobox.user.service;
+package com.uos.picobox.admin.service;
 
+import com.uos.picobox.admin.repository.AdminRepository;
 import com.uos.picobox.global.utils.SessionUtils;
 import com.uos.picobox.user.dto.SigninRequestDto;
 import com.uos.picobox.user.dto.SigninResponseDto;
-import com.uos.picobox.user.repository.CustomerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,16 +14,16 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class SigninService {
-    private final CustomerRepository customerRepository;
+public class AdminSigninService {
+    private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
     private final SessionUtils sessionUtils;
 
-    public SigninResponseDto signinCustomer(SigninRequestDto signinRequestDto) {
+    public SigninResponseDto signinAdmin(SigninRequestDto signinRequestDto) {
         String loginId = signinRequestDto.getLoginId();
         String password = signinRequestDto.getPassword();
 
-        String storedPassword = customerRepository.findPasswordByLoginId(loginId);
+        String storedPassword = adminRepository.findPasswordByLoginId(loginId);
         if (storedPassword == null) {
             throw new IllegalArgumentException("잘못된 아이디 혹은 비밀번호입니다.");
         }
@@ -33,10 +33,9 @@ public class SigninService {
             throw new IllegalArgumentException("잘못된 아이디 혹은 비밀번호입니다.");
         };
 
-        Map<String, String> sessionInfo = sessionUtils.createSession("customerSession", loginId);
+        Map<String, String> sessionInfo = sessionUtils.createSession("adminSession", loginId);
         String sessionId = sessionInfo.get("sessionId");
         String expiration = sessionInfo.get("expiration");
-
         return new SigninResponseDto(loginId, sessionId, expiration);
     }
 }

--- a/src/main/java/com/uos/picobox/admin/service/AdminSignoutService.java
+++ b/src/main/java/com/uos/picobox/admin/service/AdminSignoutService.java
@@ -1,4 +1,4 @@
-package com.uos.picobox.user.service;
+package com.uos.picobox.admin.service;
 
 import com.uos.picobox.global.utils.SessionUtils;
 import com.uos.picobox.user.dto.SignoutResponseDto;
@@ -6,21 +6,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class SignoutService {
+public class AdminSignoutService {
     private final SessionUtils sessionUtils;
 
-    public SignoutResponseDto signoutCustomer(String sessionId) {
-        Map<String, String> evictSessionInfo = sessionUtils.evictSession("customerSession", sessionId);
+    public SignoutResponseDto signoutAdmin(String sessionId) {
+        Map<String, String> evictSessionInfo = sessionUtils.evictSession("adminSession", sessionId);
         String loginId = evictSessionInfo.get("value");
         String expiration = evictSessionInfo.get("expiration");
+
         return new SignoutResponseDto(loginId, sessionId, expiration);
     }
-
 }

--- a/src/main/java/com/uos/picobox/admin/service/AdminSignupService.java
+++ b/src/main/java/com/uos/picobox/admin/service/AdminSignupService.java
@@ -1,0 +1,46 @@
+package com.uos.picobox.admin.service;
+
+import com.uos.picobox.admin.dto.AdminSignupRequestDto;
+import com.uos.picobox.admin.dto.AdminSignupResponseDto;
+import com.uos.picobox.admin.entity.Admin;
+import com.uos.picobox.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminSignupService {
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AdminSignupResponseDto registerAdmin(AdminSignupRequestDto adminSignupRequestDto) {
+        if (adminRepository.existsByLoginId(adminSignupRequestDto.getLoginId())) {
+            throw new IllegalArgumentException("loginId: " + adminSignupRequestDto.getLoginId() + "는 이미 사용 중인 로그인Id입니다.");
+        }
+        if (adminRepository.existsByEmail(adminSignupRequestDto.getEmail())) {
+            throw new IllegalArgumentException("email: " + adminSignupRequestDto.getEmail() + "는 이미 사용 중인 이메일 입니다.");
+        }
+
+        if (!adminSignupRequestDto.getAdminCode().equals("ABCD1234")) {
+            throw new IllegalArgumentException("관리자 인증 키: " + adminSignupRequestDto.getAdminCode() + "는 올바르지 않은 인증 키 입니다. 사내 부서에 문의하세요.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(adminSignupRequestDto.getPassword());
+
+        Admin admin = adminSignupRequestDto.toEntity(encodedPassword);
+        admin = adminRepository.save(admin);
+        return new AdminSignupResponseDto(admin);
+    }
+
+    public boolean isLoginIdAvailable(String loginId) {
+        return !adminRepository.existsByLoginId(loginId);
+    }
+
+    public boolean isEmailAvailable(String email) {
+        return !adminRepository.existsByEmail(email);
+    }
+}

--- a/src/main/java/com/uos/picobox/global/config/SecurityConfig.java
+++ b/src/main/java/com/uos/picobox/global/config/SecurityConfig.java
@@ -1,29 +1,36 @@
 package com.uos.picobox.global.config;
 
+import com.uos.picobox.global.exception.CustomAccessDeniedHandler;
+import com.uos.picobox.global.exception.CustomLoginAuthenticationEntryPoint;
+import com.uos.picobox.global.filter.SessionFilter;
+import com.uos.picobox.global.utils.SessionUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    private static final String[] PUBLIC_PATHS = {
-            "/health",
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/swagger/**",
-            "/error",
-            "/api/**"
+    private final CustomLoginAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final SessionUtils sessionUtils;
+
+    private static final String[] AUTH_PATHS = {
+            "/api/protected/**", "/api/admin/**", "/api/guest/**"
     };
 
     @Bean
@@ -31,12 +38,24 @@ public class SecurityConfig {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
+                // /api/** 만 인증 필터를 거치도록 설정. 나머지는 필터를 거치지 않음.
+                .securityMatcher("/api/**")
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(PUBLIC_PATHS).permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers(AUTH_PATHS).authenticated()
+                        .anyRequest().permitAll()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // Authentication Filter 추가
+                .addFilterBefore(new SessionFilter(sessionUtils, authenticationEntryPoint), UsernamePasswordAuthenticationFilter.class)
+                //세션 설정 : STATELESS
+                .sessionManagement((session) -> session
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                //exception handler
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                                .accessDeniedHandler(accessDeniedHandler));
 
         return http.build();
     }

--- a/src/main/java/com/uos/picobox/global/converter/AdminRoleConverter.java
+++ b/src/main/java/com/uos/picobox/global/converter/AdminRoleConverter.java
@@ -1,0 +1,9 @@
+package com.uos.picobox.global.converter;
+
+import com.uos.picobox.global.enumClass.AdminRole;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class AdminRoleConverter extends EnumBaseConverter<AdminRole> {
+    public AdminRoleConverter() { super(AdminRole.class); }
+}

--- a/src/main/java/com/uos/picobox/global/converter/EnumBaseConverter.java
+++ b/src/main/java/com/uos/picobox/global/converter/EnumBaseConverter.java
@@ -1,0 +1,23 @@
+package com.uos.picobox.global.converter;
+
+import com.uos.picobox.global.enumClass.BaseEnum;
+import com.uos.picobox.global.utils.EnumUtils;
+import jakarta.persistence.AttributeConverter;
+
+public abstract class EnumBaseConverter<E extends Enum<E> & BaseEnum> implements AttributeConverter<E, String> {
+    private final Class<E> enumClass;
+
+    protected EnumBaseConverter(Class<E> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(E attribute) {
+        return attribute.getValue();
+    }
+
+    @Override
+    public E convertToEntityAttribute(String dbData) {
+        return EnumUtils.fromValue(enumClass, dbData);
+    }
+}

--- a/src/main/java/com/uos/picobox/global/enumClass/AdminRole.java
+++ b/src/main/java/com/uos/picobox/global/enumClass/AdminRole.java
@@ -1,0 +1,8 @@
+package com.uos.picobox.global.enumClass;
+
+public enum AdminRole implements BaseEnum {
+    SUPER, USER_MANAGE, MOVIE_MANAGE, SCREEN_MANAGE;
+
+    @Override
+    public String getValue() { return name(); }
+}

--- a/src/main/java/com/uos/picobox/global/enumClass/BaseEnum.java
+++ b/src/main/java/com/uos/picobox/global/enumClass/BaseEnum.java
@@ -1,0 +1,5 @@
+package com.uos.picobox.global.enumClass;
+
+public interface BaseEnum {
+    String getValue();
+}

--- a/src/main/java/com/uos/picobox/global/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/uos/picobox/global/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.uos.picobox.global.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        String requestPath = request.getRequestURI();
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("status", HttpStatus.FORBIDDEN.value());
+        errorResponse.put("error", "Forbidden");
+        errorResponse.put("message", "접근 권한이 없는 사용자입니다.");
+        errorResponse.put("path", requestPath);
+
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
+    }
+
+}

--- a/src/main/java/com/uos/picobox/global/exception/CustomLoginAuthenticationEntryPoint.java
+++ b/src/main/java/com/uos/picobox/global/exception/CustomLoginAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.uos.picobox.global.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomLoginAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        String requestPath = request.getRequestURI();
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("status", HttpStatus.UNAUTHORIZED.value());
+        errorResponse.put("error", "Unauthorized");
+        errorResponse.put("message", "인증되지 않은 사용자입니다.");
+        errorResponse.put("path", requestPath);
+
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/uos/picobox/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/uos/picobox/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.uos.picobox.global.exception;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.ServletException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/uos/picobox/global/filter/SessionFilter.java
+++ b/src/main/java/com/uos/picobox/global/filter/SessionFilter.java
@@ -1,0 +1,82 @@
+package com.uos.picobox.global.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uos.picobox.global.utils.SessionUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class SessionFilter extends OncePerRequestFilter {
+    private final AntPathRequestMatcher customerMatcher = new AntPathRequestMatcher("/api/protected/**");
+    private final AntPathRequestMatcher adminMatcher = new AntPathRequestMatcher("/api/admin/**");
+    private final AntPathRequestMatcher guestMatcher = new AntPathRequestMatcher("/api/guest/**");
+    private final SessionUtils sessionUtils;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        if (customerMatcher.matches(request)) {
+            try {
+                authenticateBySession(request, response, "customerSession", "CUSTOMER");
+            } catch (IOException e) {
+                return;
+            }
+
+        }
+        else if (adminMatcher.matches(request)) {
+            try {
+                authenticateBySession(request, response, "adminSession", "ADMIN");
+            } catch (IOException e) {
+                return;
+            }
+        }
+        else if (guestMatcher.matches(request)) {
+            try {
+                authenticateBySession(request, response, "guestSession", "GUEST");
+            } catch (IOException e) {
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateBySession(HttpServletRequest request, HttpServletResponse response, String cacheName, String role) throws ServletException, IOException {
+        String sessionId = request.getHeader("Authorization");
+        if (sessionId == null) {
+            authenticationEntryPoint.commence(
+                    request,
+                    response,
+                    new InsufficientAuthenticationException("Authorization 헤더가 존재하지 않습니다.")
+            );
+            throw new IOException("Authorization 헤더가 존재하지 않습니다.");
+        }
+
+        String loginId = sessionUtils.existSession(cacheName, sessionId);
+        List<SimpleGrantedAuthority> authorities =
+                Collections.singletonList(new SimpleGrantedAuthority(role));
+
+        // Authentication 객체 생성
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(loginId, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/uos/picobox/global/service/EmailService.java
+++ b/src/main/java/com/uos/picobox/global/service/EmailService.java
@@ -2,7 +2,7 @@ package com.uos.picobox.global.service;
 
 import com.uos.picobox.user.dto.AuthMailRequestDto;
 import com.uos.picobox.user.dto.MailRequestDto;
-import com.uos.picobox.global.utils.EmailUtil;
+import com.uos.picobox.global.utils.EmailUtils;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import java.time.format.DateTimeFormatter;
 @Service
 @RequiredArgsConstructor
 public class EmailService {
-    private final EmailUtil emailUtil;
+    private final EmailUtils emailUtils;
     private final CacheManager cacheManager;
 
     public void sendAuthMail(MailRequestDto mailRequestDto) throws MessagingException {
@@ -26,7 +26,7 @@ public class EmailService {
 
         String email = mailRequestDto.getEmail();
         String purpose = mailRequestDto.getPurpose();
-        String authCode = emailUtil.createAuthCode();
+        String authCode = emailUtils.createAuthCode();
         String body = """
             <html>
               <body style="font-family: 'Apple SD Gothic Neo', Arial, sans-serif; background-color: #f6f6f6; padding: 40px;">
@@ -56,8 +56,8 @@ public class EmailService {
               </body>
             </html>
             """.formatted(purpose, authCode, formattedExpiration);
-        MimeMessage newMail = emailUtil.createMail(email,purpose +" 인증 번호를 보내드려요.", body);
-        emailUtil.sendMail(newMail);
+        MimeMessage newMail = emailUtils.createMail(email,purpose +" 인증 번호를 보내드려요.", body);
+        emailUtils.sendMail(newMail);
         Cache cache = cacheManager.getCache("emailAuthCode");
         Objects.requireNonNull(cache).put(email, authCode);
     }

--- a/src/main/java/com/uos/picobox/global/utils/EmailUtils.java
+++ b/src/main/java/com/uos/picobox/global/utils/EmailUtils.java
@@ -12,7 +12,7 @@ import java.util.Random;
 
 @Component
 @RequiredArgsConstructor
-public class EmailUtil {
+public class EmailUtils {
     private final JavaMailSender mailSender;
     @Value("${spring.mail.username}")
     private String sender;

--- a/src/main/java/com/uos/picobox/global/utils/EnumUtils.java
+++ b/src/main/java/com/uos/picobox/global/utils/EnumUtils.java
@@ -1,0 +1,20 @@
+package com.uos.picobox.global.utils;
+
+
+import com.uos.picobox.global.enumClass.BaseEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EnumUtils {
+    /** enum 클래스에서 특정 값을 가진 원소를 찾습니다. */
+    public static <T extends Enum<T> & BaseEnum> T fromValue(Class<T> enumClass, String value) {
+        for (T enumConstant : enumClass.getEnumConstants()) {
+            if (enumConstant.getValue().equals(value)) {
+                return enumConstant;
+            }
+        }
+        throw new IllegalArgumentException("해당 "+enumClass.getName() +" 값은 존재하지 않습니다: " + value);
+    }
+}

--- a/src/main/java/com/uos/picobox/global/utils/SessionUtils.java
+++ b/src/main/java/com/uos/picobox/global/utils/SessionUtils.java
@@ -1,0 +1,59 @@
+package com.uos.picobox.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class SessionUtils {
+    private final CacheManager cacheManager;
+
+    public Map<String, String> createSession(String cacheName, String value) {
+        String sessionId = java.util.UUID.randomUUID().toString();
+        Cache cache = cacheManager.getCache(cacheName);
+        Objects.requireNonNull(cache).put(sessionId, value);
+
+        String expiration = LocalDateTime.now()
+                .plusHours(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        return Map.of(
+                "sessionId", sessionId,
+                "expiration", expiration
+        );
+    }
+
+    public Map<String, String> evictSession(String cacheName, String sessionId) {
+        Cache cache = cacheManager.getCache(cacheName);
+        Cache.ValueWrapper wrapper = Objects.requireNonNull(cache).get(sessionId);
+        if (Objects.isNull(wrapper)) {
+            throw new IllegalArgumentException("잘못된 session이거나 이미 만료된 session입니다.");
+        }
+        cache.evict(sessionId);
+
+        String value = (String) wrapper.get();
+        LocalDateTime expirationTime = LocalDateTime.now();
+        String formattedExpiration = expirationTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        return Map.of(
+                "value", Objects.requireNonNull(value),
+                "expiration", formattedExpiration
+        );
+    }
+
+    public String existSession(String cacheName, String sessionId) {
+        Cache cache = cacheManager.getCache(cacheName);
+        Cache.ValueWrapper wrapper = Objects.requireNonNull(cache).get(sessionId);
+        if (Objects.isNull(wrapper)) {
+            throw new IllegalArgumentException("잘못된 session이거나 이미 만료된 session입니다.");
+        }
+        String value = (String) wrapper.get();
+        return Objects.requireNonNull(value);
+    }
+}

--- a/src/main/java/com/uos/picobox/user/controller/GuestSignController.java
+++ b/src/main/java/com/uos/picobox/user/controller/GuestSignController.java
@@ -1,10 +1,8 @@
 package com.uos.picobox.user.controller;
 
-import com.uos.picobox.user.dto.SigninRequestDto;
-import com.uos.picobox.user.dto.SigninResponseDto;
-import com.uos.picobox.user.dto.SignoutResponseDto;
-import com.uos.picobox.user.service.SigninService;
-import com.uos.picobox.user.service.SignoutService;
+import com.uos.picobox.user.dto.*;
+import com.uos.picobox.user.service.GuestSigninService;
+import com.uos.picobox.user.service.GuestSignoutService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,39 +15,39 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "회원 - 01. 로그인, 로그아웃", description = "회원 정보를 처리합니다.")
+@Tag(name = "비회원 - 01. 로그인, 로그아웃", description = "비회원 정보를 처리합니다.")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class SignController {
-    private final SigninService signinService;
-    private final SignoutService signoutService;
+public class GuestSignController {
+    private final GuestSigninService guestSigninService;
+    private final GuestSignoutService guestSignoutService;
 
-    @Operation(summary = "회원 로그인", description = "회원 로그인을 처리합니다.")
+    @Operation(summary = "비회원 로그인", description = "비회원 로그인을 처리합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 로그인을 성공했습니다."),
+            @ApiResponse(responseCode = "200", description = "비회원 로그인을 성공했습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 올바르지 못한 loginId or Password)."),
             @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
     })
-    @PostMapping("/signin/customer")
+    @PostMapping("/signin/guest")
     public ResponseEntity<?> signin(
-            @Valid @RequestBody SigninRequestDto signinRequestDto) {
-        SigninResponseDto response = signinService.signinCustomer(signinRequestDto);
+            @Valid @RequestBody GuestSigninRequestDto signinRequestDto) {
+        GuestSigninResponseDto response = guestSigninService.signinGuest(signinRequestDto);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "회원 로그아웃", description = "회원 로그아웃을 처리합니다.", security = @SecurityRequirement(name = "sessionAuth"))
+    @Operation(summary = "비회원 로그아웃", description = "비회원 로그아웃을 처리합니다.", security = @SecurityRequirement(name = "sessionAuth"))
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 로그아웃을 성공했습니다."),
+            @ApiResponse(responseCode = "200", description = "비회원 로그아웃을 성공했습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 올바르지 못한 sessionId or 만료된 sessionId)."),
             @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
     })
-    @PostMapping("/signout/customer")
+    @PostMapping("/signout/guest")
     public ResponseEntity<?> signout(
             @Parameter(hidden = true)
             @RequestHeader("Authorization") String sessionId
     ) {
-        SignoutResponseDto response = signoutService.signoutCustomer(sessionId);
+        GuestSignoutResponseDto response = guestSignoutService.signoutGuest(sessionId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/uos/picobox/user/controller/GuestSignupController.java
+++ b/src/main/java/com/uos/picobox/user/controller/GuestSignupController.java
@@ -1,11 +1,8 @@
 package com.uos.picobox.user.controller;
 
-import com.uos.picobox.user.dto.AuthMailRequestDto;
-import com.uos.picobox.user.dto.MailRequestDto;
-import com.uos.picobox.user.dto.SignupRequestDto;
-import com.uos.picobox.user.dto.SignupResponseDto;
 import com.uos.picobox.global.service.EmailService;
-import com.uos.picobox.user.service.SignupService;
+import com.uos.picobox.user.dto.*;
+import com.uos.picobox.user.service.GuestSignupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,55 +12,35 @@ import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-//"회원가입, 로그인 아이디 중복 검사, 이메일 중복 검사, 이메일 인증 코드 전송, 이메일 인증 코드 인증"
-@Tag(name = "회원 - 00. 회원 가입", description = "회원가입 관련 API를 제공합니다.")
+@Tag(name = "비회원 - 00. 비회원 등록", description = "비회원 등록 관련 API를 제공합니다.")
 @RestController
-@RequestMapping("/api/signup/customer")
+@RequestMapping("/api/signup/guest")
 @RequiredArgsConstructor
-public class SignupController {
+public class GuestSignupController {
 
-    private final SignupService signupService;
+    private final GuestSignupService guestSignupService;
     private final EmailService emailService;
 
-    @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
+    @Operation(summary = "비회원 등록", description = "비회원 정보를 등록합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "새로운 회원이 성공적으로 등록되었습니다."),
+            @ApiResponse(responseCode = "201", description = "비회원 정보가 성공적으로 등록되었습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 회원 정보)."),
             @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
     })
     @PostMapping("")
     public ResponseEntity<?> signup(
-            @Valid @RequestBody SignupRequestDto signupRequestDto) {
+            @Valid @RequestBody GuestSignupRequestDto signupRequestDto) {
         if (!signupRequestDto.getPassword().equals(signupRequestDto.getRepeatPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
-        SignupResponseDto response = signupService.registerCustomer(signupRequestDto);
+        GuestSignupResponseDto response = guestSignupService.registerGuest(signupRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
-
-    @Validated
-    @Operation(summary = "로그인ID 중복 검사", description = "로그인ID 중복 여부를 검사합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용할 수 있는 로그인ID입니다."),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(예: 유효성 검사 실패, 중복된 로그인ID)."),
-            @ApiResponse(responseCode = "500", description = "서버 오류입니다.")
-    })
-    @GetMapping("/check/loginid")
-    public ResponseEntity<?> checkLoginId(
-            @RequestParam
-            @NotBlank
-            @Size(min = 1, max = 12, message = "1~12자 사이여야 합니다.")
-            @Schema(description = "로그인 아이디", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
-            String loginId) {
-        boolean response = signupService.isLoginIdAvailable(loginId);
-        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @Validated
@@ -80,7 +57,7 @@ public class SignupController {
             @Email(message = "이메일 형식이어야 합니다.")
             @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
             String email) {
-        boolean response = signupService.isEmailAvailable(email);
+        boolean response = guestSignupService.isEmailAvailable(email);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
@@ -95,7 +72,7 @@ public class SignupController {
             @RequestBody
             @Valid
             MailRequestDto mailRequestDto) throws MessagingException {
-        if (!signupService.isEmailAvailable(mailRequestDto.getEmail())) {
+        if (!guestSignupService.isEmailAvailable(mailRequestDto.getEmail())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.");
         }
         emailService.sendAuthMail(mailRequestDto);
@@ -113,7 +90,7 @@ public class SignupController {
             @RequestBody
             @Valid
             AuthMailRequestDto authMailRequestDto) {
-        if (!signupService.isEmailAvailable(authMailRequestDto.getEmail())) {
+        if (!guestSignupService.isEmailAvailable(authMailRequestDto.getEmail())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다. 다른 이메일을 입력해주세요.");
         }
         emailService.checkAuthCode(authMailRequestDto);

--- a/src/main/java/com/uos/picobox/user/dto/GuestSigninRequestDto.java
+++ b/src/main/java/com/uos/picobox/user/dto/GuestSigninRequestDto.java
@@ -1,0 +1,29 @@
+package com.uos.picobox.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GuestSigninRequestDto {
+
+    @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Email(message = "이메일 형식이어야 합니다.")
+    private String email;
+
+    /*@Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#\\$%^&*()_+\\-={}:;\"'<>?,./]).+$",
+            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+    ) */
+    @Schema(description = "비밀번호", example = "P@ssw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Size(min = 4, max = 20, message = "비밀번호는 4자 이상 20자 이하이어야 합니다.")
+    private String password;
+}

--- a/src/main/java/com/uos/picobox/user/dto/GuestSigninResponseDto.java
+++ b/src/main/java/com/uos/picobox/user/dto/GuestSigninResponseDto.java
@@ -1,0 +1,23 @@
+package com.uos.picobox.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GuestSigninResponseDto {
+
+    @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
+
+    @Schema(description = "login session info", example = "a3dxg-923a12-xyz", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String sessionId;
+
+    @Schema(description = "로그인 만료 시간", example = "2024-01-01 10:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String expiresAt;
+}

--- a/src/main/java/com/uos/picobox/user/dto/GuestSignoutResponseDto.java
+++ b/src/main/java/com/uos/picobox/user/dto/GuestSignoutResponseDto.java
@@ -8,9 +8,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class SignoutResponseDto {
-    @Schema(description = "로그인 아이디", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
-    private String loginId;
+public class GuestSignoutResponseDto {
+    @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
 
     @Schema(description = "login session info", example = "a3dxg-923a12-xyz", requiredMode = Schema.RequiredMode.REQUIRED)
     private String sessionId;

--- a/src/main/java/com/uos/picobox/user/dto/GuestSignupRequestDto.java
+++ b/src/main/java/com/uos/picobox/user/dto/GuestSignupRequestDto.java
@@ -1,0 +1,61 @@
+package com.uos.picobox.user.dto;
+
+import com.uos.picobox.user.entity.Guest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GuestSignupRequestDto {
+
+    @Schema(description = "이름", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String name;
+
+    @Schema(description = "이메일 주소", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Email(message = "이메일 형식이어야 합니다.")
+    private String email;
+
+    @Schema(description = "생년월일", example = "1990-01-01", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private LocalDate birthdate;
+
+    @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Pattern(regexp = "^(010|011|016|017|018|019)-?\\d{3,4}-?\\d{4}$", message = "전화번호 형식이어야 합니다.")
+    private String phone;
+
+    /*@Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#\\$%^&*()_+\\-={}:;\"'<>?,./]).+$",
+            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+    ) */
+    @Schema(description = "비밀번호", example = "P@ssw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    @Size(min = 4, max = 20, message = "비밀번호는 4자 이상 20자 이하이어야 합니다.")
+    private String password;
+
+    @Schema(description = "비밀번호 확인", example = "P@ssw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String repeatPassword;
+
+    public Guest toEntity(String encodedPassword, LocalDateTime expirationDate) {
+        return Guest.builder()
+                .name(this.name)
+                .email(this.email)
+                .birthDate(this.birthdate)
+                .phone(this.phone)
+                .password(encodedPassword)
+                .expirationDate(expirationDate)
+                .build();
+    }
+}

--- a/src/main/java/com/uos/picobox/user/dto/GuestSignupResponseDto.java
+++ b/src/main/java/com/uos/picobox/user/dto/GuestSignupResponseDto.java
@@ -1,0 +1,46 @@
+package com.uos.picobox.user.dto;
+
+import com.uos.picobox.user.entity.Guest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class GuestSignupResponseDto {
+    @Schema(description = "비회원 고유 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "이메일 주소", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "생년월일", example = "1990-01-01")
+    private LocalDate birthDate;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+
+    @Schema(description = "만료시간", example = "2024-04-10T14:00:00")
+    private LocalDateTime expirationDate;
+
+    @Schema(description = "login session info", example = "a3dxg-923a12-xyz", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String sessionId;
+
+    @Schema(description = "로그인 만료 시간", example = "2024-01-01 10:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String expiresAt;
+
+    public GuestSignupResponseDto(Guest guest, String sessionId, String expiresAt) {
+        this.id = guest.getId();
+        this.name = guest.getName();
+        this.email = guest.getEmail();
+        this.birthDate = guest.getBirthDate();
+        this.phone = guest.getPhone();
+        this.expirationDate = guest.getExpirationDate();
+        this.sessionId = sessionId;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/uos/picobox/user/repository/GuestRepository.java
+++ b/src/main/java/com/uos/picobox/user/repository/GuestRepository.java
@@ -1,4 +1,18 @@
 package com.uos.picobox.user.repository;
 
-public interface GuestRepository {
+import com.uos.picobox.user.entity.Guest;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface GuestRepository extends JpaRepository<Guest, Long> {
+    boolean existsByEmail(String email);
+    @Query("SELECT g.password FROM Guest g WHERE g.email = :email")
+    String findPasswordByEmail(@Param("email") String email);
+    @Modifying
+    @Query("DELETE FROM Guest g WHERE g.expirationDate < :threshold ")
+    void deleteExpiredGuests(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/uos/picobox/user/scheduler/GuestScheduler.java
+++ b/src/main/java/com/uos/picobox/user/scheduler/GuestScheduler.java
@@ -1,0 +1,22 @@
+package com.uos.picobox.user.scheduler;
+
+import com.uos.picobox.user.repository.GuestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class GuestScheduler {
+    private final GuestRepository guestRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 * * * *")
+    public void deleteExpiredGuests() {
+        LocalDateTime threshold = LocalDateTime.now();
+        guestRepository.deleteExpiredGuests(threshold);
+    }
+}

--- a/src/main/java/com/uos/picobox/user/service/GuestSigninService.java
+++ b/src/main/java/com/uos/picobox/user/service/GuestSigninService.java
@@ -1,0 +1,42 @@
+package com.uos.picobox.user.service;
+
+import com.uos.picobox.global.utils.SessionUtils;
+import com.uos.picobox.user.dto.GuestSigninRequestDto;
+import com.uos.picobox.user.dto.GuestSigninResponseDto;
+import com.uos.picobox.user.repository.GuestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GuestSigninService {
+    private final GuestRepository guestRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SessionUtils sessionUtils;
+
+    public GuestSigninResponseDto signinGuest(GuestSigninRequestDto guestSigninRequestDto) {
+        String email = guestSigninRequestDto.getEmail();
+        String password = guestSigninRequestDto.getPassword();
+
+        String storedPassword = guestRepository.findPasswordByEmail(email);
+        if (storedPassword == null) {
+            throw new IllegalArgumentException("잘못된 이메일 혹은 비밀번호입니다.");
+        }
+
+        // password is not matched
+        if (!passwordEncoder.matches(password, storedPassword)) {
+            throw new IllegalArgumentException("잘못된 이메일 혹은 비밀번호입니다.");
+        };
+
+        Map<String, String> sessionInfo = sessionUtils.createSession("guestSession", email);
+        String sessionId = sessionInfo.get("sessionId");
+        String expiration = sessionInfo.get("expiration");
+
+        return new GuestSigninResponseDto(email, sessionId, expiration);
+    }
+}

--- a/src/main/java/com/uos/picobox/user/service/GuestSignoutService.java
+++ b/src/main/java/com/uos/picobox/user/service/GuestSignoutService.java
@@ -1,26 +1,24 @@
 package com.uos.picobox.user.service;
 
 import com.uos.picobox.global.utils.SessionUtils;
+import com.uos.picobox.user.dto.GuestSignoutResponseDto;
 import com.uos.picobox.user.dto.SignoutResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class SignoutService {
+public class GuestSignoutService {
     private final SessionUtils sessionUtils;
 
-    public SignoutResponseDto signoutCustomer(String sessionId) {
-        Map<String, String> evictSessionInfo = sessionUtils.evictSession("customerSession", sessionId);
-        String loginId = evictSessionInfo.get("value");
+    public GuestSignoutResponseDto signoutGuest(String sessionId) {
+        Map<String, String> evictSessionInfo = sessionUtils.evictSession("guestSession", sessionId);
+        String email = evictSessionInfo.get("value");
         String expiration = evictSessionInfo.get("expiration");
-        return new SignoutResponseDto(loginId, sessionId, expiration);
+        return new GuestSignoutResponseDto(email, sessionId, expiration);
     }
-
 }

--- a/src/main/java/com/uos/picobox/user/service/GuestSignupService.java
+++ b/src/main/java/com/uos/picobox/user/service/GuestSignupService.java
@@ -1,0 +1,49 @@
+package com.uos.picobox.user.service;
+
+import com.uos.picobox.global.utils.SessionUtils;
+import com.uos.picobox.user.dto.GuestSignupRequestDto;
+import com.uos.picobox.user.dto.GuestSignupResponseDto;
+import com.uos.picobox.user.entity.Guest;
+import com.uos.picobox.user.repository.GuestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GuestSignupService {
+
+    private final GuestRepository guestRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SessionUtils sessionUtils;
+
+    @Transactional
+    public GuestSignupResponseDto registerGuest(GuestSignupRequestDto guestSignupRequestDto) {
+        if (guestRepository.existsByEmail(guestSignupRequestDto.getEmail())) {
+            throw new IllegalArgumentException("email: " + guestSignupRequestDto.getEmail() + "는 이미 사용 중인 이메일 입니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(guestSignupRequestDto.getPassword());
+        // 6시간 후 만료로 설정 후 예매 시 상영 종료 시점까지 연장.
+        LocalDateTime expirationDate = LocalDateTime.now().plusHours(6);
+
+        Guest guest = guestSignupRequestDto.toEntity(encodedPassword, expirationDate);
+        guest = guestRepository.save(guest);
+
+        Map<String, String> sessionInfo = sessionUtils.createSession("guestSession", guest.getEmail());
+        String sessionId = sessionInfo.get("sessionId");
+        String expiration = sessionInfo.get("expiration");
+
+        return new GuestSignupResponseDto(guest, sessionId, expiration);
+    }
+
+
+    public boolean isEmailAvailable(String email) {
+        return !guestRepository.existsByEmail(email);
+    }
+}

--- a/src/main/java/com/uos/picobox/user/service/SignupService.java
+++ b/src/main/java/com/uos/picobox/user/service/SignupService.java
@@ -20,10 +20,10 @@ public class SignupService {
     @Transactional
     public SignupResponseDto registerCustomer(SignupRequestDto signupRequestDto) {
         if (customerRepository.existsByLoginId(signupRequestDto.getLoginId())) {
-            throw new IllegalArgumentException("Customer with loginId " + signupRequestDto.getLoginId() + " already exists.");
+            throw new IllegalArgumentException("loginId: " + signupRequestDto.getLoginId() + "는 이미 사용 중인 로그인Id입니다.");
         }
         if (customerRepository.existsByEmail(signupRequestDto.getEmail())) {
-            throw new IllegalArgumentException("Customer with email " + signupRequestDto.getEmail() + " already exists.");
+            throw new IllegalArgumentException("email: " + signupRequestDto.getEmail() + "는 이미 사용 중인 이메일 입니다.");
         }
 
         String encodedPassword = passwordEncoder.encode(signupRequestDto.getPassword());


### PR DESCRIPTION
- 관리자 가입, 로그인, 로그아웃 API
- 관리자 가입의 경우 adminCode는 swagger 상의 adminCode를 그대로 사용. 사내에서 발급받은 adminCode를 사용한다는 컨셉.
- 비회원 등록, 로그인, 로그아웃 API
- 비회원은 등록 시 session 등록도 같이 진행해 별도의 로그인을 또 할 필요는 없음.
- 비회원 만료 시간은 6시간. 여기서 예매를 할 시에는 영화 상영 종료 시간으로 만료 시간이 늘어나게 로직 추가 예정
- 인증 로직
- '/api/admin/**' -> 관리자 인증이 필요한 모든 API.
- '/api/protected/**' -> 회원 인증이 필요한 모든 API.
- '/api/guest/**' -> 비회원 인증이 필요한 모든 API.
- 그 외 인증 path와 꼬이는 것을 막기 위해 기존 회원가입, 로그인, 로그아웃의 API Path를 수정. -> swagger 참고.
resolves: issues/#16